### PR TITLE
Pluggable training backend seam

### DIFF
--- a/src/exex/__init__.py
+++ b/src/exex/__init__.py
@@ -1,4 +1,5 @@
 from exex.arch import MoEArch, iter_moe_layers
+from exex.backends import get_backend, register_backend
 from exex.manager import ExpertManager
 from exex.surgery import prepare_expert_for_training
 from exex.trainer import ExpertTrainer
@@ -6,6 +7,8 @@ from exex.trainer import ExpertTrainer
 __all__ = [
     "MoEArch",
     "iter_moe_layers",
+    "get_backend",
+    "register_backend",
     "ExpertManager",
     "prepare_expert_for_training",
     "ExpertTrainer",

--- a/src/exex/backends.py
+++ b/src/exex/backends.py
@@ -1,0 +1,76 @@
+"""
+Pluggable training backends.
+
+exex's surgery/expert-selection layer is backend-agnostic; a backend owns
+the optimizer and the forward/backward/step machinery. The bare-PyTorch
+backend is the always-working reference. Optimized backends (unsloth,
+ht-unsloth, ...) register themselves here and are imported lazily, so a
+missing dependency never breaks the core.
+"""
+
+import importlib
+
+import torch
+
+_REGISTRY = {}
+
+
+def register_backend(name):
+    def decorator(cls):
+        _REGISTRY[name] = cls
+        return cls
+    return decorator
+
+
+def get_backend(name="torch"):
+    """Instantiate a backend by name. Raises with guidance if unavailable."""
+    if name not in _REGISTRY:
+        raise ValueError(
+            f"Unknown backend {name!r} (available: {sorted(_REGISTRY)})"
+        )
+    return _REGISTRY[name]()
+
+
+@register_backend("torch")
+class TorchBackend:
+    """Reference backend: plain PyTorch Adam + eager forward/backward."""
+
+    def create_optimizer(self, param_groups):
+        return torch.optim.Adam(param_groups)
+
+    def backward_and_step(self, loss, optimizer):
+        loss.backward()
+        optimizer.step()
+
+
+class _LazyImportBackend:
+    """Base for backends wrapping an optional third-party package."""
+
+    package = None  # override
+
+    def __init__(self):
+        try:
+            self._module = importlib.import_module(self.package)
+        except ImportError as e:
+            raise ImportError(
+                f"Backend requires the {self.package!r} package, which is "
+                f"not installed. Install it or use backend='torch'."
+            ) from e
+        self._check_support()
+
+    def _check_support(self):
+        raise NotImplementedError
+
+
+@register_backend("unsloth")
+class UnslothBackend(_LazyImportBackend):
+    """Placeholder adapter: fails informatively until expert-subset training
+    lands upstream. Tracked in exex issue #6."""
+
+    package = "unsloth"
+
+    def _check_support(self):
+        raise NotImplementedError(
+            "unsloth does not yet expose MoE expert-subset training; "
+            "this adapter is a stub. Use backend='torch'."
+        )

--- a/src/exex/trainer.py
+++ b/src/exex/trainer.py
@@ -40,7 +40,10 @@ class ExpertTrainer:
         kl_weight=0.1,
         lr=1e-4,
         router_lr_scale=0.1,
+        backend="torch",
     ):
+        from exex.backends import get_backend
+        self.backend = get_backend(backend) if isinstance(backend, str) else backend
         self.model = model
         self.target_expert_indices = (
             [target_expert_indices]
@@ -81,7 +84,7 @@ class ExpertTrainer:
             p for n, p in model.named_parameters()
             if p.requires_grad and "router" in n
         ]
-        self.optimizer = torch.optim.Adam([
+        self.optimizer = self.backend.create_optimizer([
             {"params": expert_params, "lr": lr},
             {"params": router_params, "lr": lr * router_lr_scale},
         ])
@@ -204,8 +207,7 @@ class ExpertTrainer:
         task_loss, kl_loss = self.compute_loss(input_ids, labels, **kwargs)
         total_loss = task_loss + self.kl_weight * kl_loss
 
-        total_loss.backward()
-        self.optimizer.step()
+        self.backend.backward_and_step(total_loss, self.optimizer)
 
         return {
             "task_loss": task_loss.item(),

--- a/src/exex/trainer.py
+++ b/src/exex/trainer.py
@@ -12,6 +12,7 @@ import torch.nn.functional as F
 from transformers import Gemma4ForCausalLM
 
 from exex.arch import iter_moe_layers
+from exex.backends import get_backend
 from exex.surgery import prepare_expert_for_training
 
 # Patch from_config onto Gemma4ForCausalLM if not present (uses _from_config internally)
@@ -42,7 +43,6 @@ class ExpertTrainer:
         router_lr_scale=0.1,
         backend="torch",
     ):
-        from exex.backends import get_backend
         self.backend = get_backend(backend) if isinstance(backend, str) else backend
         self.model = model
         self.target_expert_indices = (

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,31 @@
+import pytest
+import torch
+
+from exex.backends import get_backend, TorchBackend
+from exex.trainer import ExpertTrainer
+
+
+class TestRegistry:
+    def test_torch_backend(self):
+        backend = get_backend("torch")
+        assert isinstance(backend, TorchBackend)
+
+    def test_unknown_backend(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            get_backend("nope")
+
+    def test_unsloth_stub_fails_informatively(self):
+        with pytest.raises((ImportError, NotImplementedError)):
+            get_backend("unsloth")
+
+
+class TestTrainerIntegration:
+    def test_explicit_torch_backend_trains(self, tiny_gemma4_moe, sample_batch):
+        trainer = ExpertTrainer(tiny_gemma4_moe, [1], backend="torch")
+        metrics = trainer.train_step(**sample_batch)
+        assert torch.isfinite(torch.tensor(metrics["total_loss"]))
+
+    def test_backend_instance_accepted(self, tiny_gemma4_moe, sample_batch):
+        trainer = ExpertTrainer(tiny_gemma4_moe, [1], backend=TorchBackend())
+        metrics = trainer.train_step(**sample_batch)
+        assert torch.isfinite(torch.tensor(metrics["total_loss"]))


### PR DESCRIPTION
Adds the backend abstraction from #6: a registry with a bare-PyTorch reference backend (always works), lazy-import wrappers for optional third-party backends, and an informative unsloth stub. `ExpertTrainer` now takes `backend=` (name or instance); optimizer creation and backward/step are delegated.

Deliberately minimal: no speculative adapter API beyond what the trainer actually calls today (`create_optimizer`, `backward_and_step`) — the surface grows when a real optimized backend lands.

Test plan: 50 CPU tests green, including new registry tests and trainer runs with explicit backend name and instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)