### PR TITLE
fix: locate decoder layers under multimodal wrappers

### DIFF
--- a/src/exex/arch.py
+++ b/src/exex/arch.py
@@ -113,6 +113,10 @@ class MoEArch:
 
 def _decoder_layers(model):
     inner = getattr(model, "model", model)
+    # Multimodal wrappers (e.g. Gemma4ForConditionalGeneration) nest the
+    # decoder under .language_model next to a vision tower.
+    if not hasattr(inner, "layers") and hasattr(inner, "language_model"):
+        inner = inner.language_model
     return inner.layers
 
 

--- a/tests/test_arch.py
+++ b/tests/test_arch.py
@@ -33,6 +33,18 @@ class TestMoEArch:
         arch.sync_config(tiny_gemma4_moe.config)
         assert tiny_gemma4_moe.config.num_experts == 7
 
+    def test_multimodal_wrapper_layers_found(self, tiny_gemma4_moe):
+        """ConditionalGeneration-style wrappers nest layers under .language_model."""
+        class Wrapper:
+            pass
+        wrapper = Wrapper()
+        wrapper.model = Wrapper()
+        wrapper.model.language_model = tiny_gemma4_moe.model
+        wrapper.config = tiny_gemma4_moe.config
+        assert len(list(iter_moe_layers(wrapper))) == 2
+        arch = MoEArch.from_model(wrapper)
+        assert arch.num_experts == 4
+
     def test_non_moe_config_raises(self):
         class Dummy:
             num_hidden_layers = 2


### PR DESCRIPTION
One-line fix + regression test from the first real-hardware smoke run: the 26B checkpoint loads as Gemma4ForConditionalGeneration, whose decoder layers live at model.language_model.layers. Merging directly — verified on GH200 by the clerk's overlay run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)