### PR TITLE
fix: accept local json/jsonl file paths in dataset CLI args

### DIFF
--- a/scripts/prune_experts.py
+++ b/scripts/prune_experts.py
@@ -20,7 +20,10 @@ from exex.pruner import (
 
 def calibration_batches(dataset_name, tokenizer, text_column, max_samples, max_length):
     from datasets import load_dataset
-    dataset = load_dataset(dataset_name, split="train")
+    if os.path.isfile(dataset_name):
+        dataset = load_dataset("json", data_files=dataset_name, split="train")
+    else:
+        dataset = load_dataset(dataset_name, split="train")
     for i in range(min(max_samples, len(dataset))):
         yield tokenizer(
             dataset[i][text_column], return_tensors="pt",

--- a/scripts/train_expert.py
+++ b/scripts/train_expert.py
@@ -69,9 +69,12 @@ def main():
         router_lr_scale=args.router_lr_scale,
     )
 
-    # Load dataset
+    # Load dataset (local json/jsonl file or HF dataset name)
     print(f"Loading dataset {args.dataset}...")
-    dataset = load_dataset(args.dataset, split="train")
+    if os.path.isfile(args.dataset):
+        dataset = load_dataset("json", data_files=args.dataset, split="train")
+    else:
+        dataset = load_dataset(args.dataset, split="train")
 
     # Training loop
     print(f"Training experts {expert_indices} for {args.max_steps} steps...")


### PR DESCRIPTION
Second real-hardware finding from the clerk's smoke run: local JSONL paths need the json builder. Applied to both train and prune CLIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)