### PR TITLE
fix: compute router KL in fp32 to avoid small negative values in bf16

### DIFF
--- a/src/exex/trainer.py
+++ b/src/exex/trainer.py
@@ -162,8 +162,10 @@ class ExpertTrainer:
                     ref["proj_weight"].to(device),
                 )
 
-            current_log_probs = F.log_softmax(current_logits, dim=-1)
-            ref_probs = F.softmax(ref_logits, dim=-1)
+            # fp32 for the divergence itself: at KL ~ 0 (early training),
+            # bf16/fp16 rounding yields small negative values
+            current_log_probs = F.log_softmax(current_logits.float(), dim=-1)
+            ref_probs = F.softmax(ref_logits.float(), dim=-1)
 
             kl = F.kl_div(current_log_probs, ref_probs, reduction="batchmean")
             total_kl = total_kl + kl

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,5 +1,15 @@
 import pytest
 import torch
+
+
+class TestKLNumerics:
+    def test_kl_nonnegative_in_half_precision(self, tiny_gemma4_moe, sample_batch):
+        from exex.trainer import ExpertTrainer
+        model = tiny_gemma4_moe.to(torch.bfloat16)
+        trainer = ExpertTrainer(model, [1])
+        _, kl_loss = trainer.compute_loss(**sample_batch)
+        assert kl_loss.item() >= 0.0
+        assert torch.isfinite(kl_loss)
 from exex.trainer import ExpertTrainer
 
 


### PR DESCRIPTION
Finding 5 from the passing smoke run: slightly negative KL under bf16. Regression test runs the trainer on a bf16 model and asserts KL >= 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)