### PR TITLE
fix: bf16 default load dtype for extract/merge CLIs

### DIFF
--- a/scripts/extract_experts.py
+++ b/scripts/extract_experts.py
@@ -22,6 +22,10 @@ def main():
     parser.add_argument("--labels", default=None,
                         help='JSON dict {"name": ["label", ...]}')
     parser.add_argument("--output", required=True, help="Cartridge .safetensors path")
+    parser.add_argument("--dtype", default="bfloat16",
+                        choices=["bfloat16", "float16", "float32"],
+                        help="Load dtype; bf16 default matches native Gemma 4 "
+                             "checkpoints (fp16 casts lose precision / overflow)")
     args = parser.parse_args()
 
     try:
@@ -32,7 +36,7 @@ def main():
 
     print(f"Loading model from {args.model_path}...")
     model = AutoModelForCausalLM.from_pretrained(
-        args.model_path, torch_dtype=torch.float16, device_map="cpu"
+        args.model_path, torch_dtype=getattr(torch, args.dtype), device_map="cpu"
     )
     cart = save_cartridge(
         model, experts, args.output, source_model=args.model_path, labels=labels

--- a/scripts/merge_experts.py
+++ b/scripts/merge_experts.py
@@ -25,6 +25,10 @@ def main():
                         help="1.0 = replace, 0.5 = average with incumbent")
     parser.add_argument("--merge_config", help="JSON file with a list of installs")
     parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--dtype", default="bfloat16",
+                        choices=["bfloat16", "float16", "float32"],
+                        help="Load dtype; bf16 default matches native Gemma 4 "
+                             "checkpoints (fp16 casts lose precision / overflow)")
     args = parser.parse_args()
 
     if bool(args.merge_config) == bool(args.cartridge):
@@ -32,7 +36,7 @@ def main():
 
     print(f"Loading model from {args.model_path}...")
     model = AutoModelForCausalLM.from_pretrained(
-        args.model_path, torch_dtype=torch.float16, device_map="cpu"
+        args.model_path, torch_dtype=getattr(torch, args.dtype), device_map="cpu"
     )
 
     if args.merge_config:


### PR DESCRIPTION
fp16 casts of natively-bf16 Gemma 4 checkpoints lose precision and can overflow (the trainer got the same fix in #18). Adds `--dtype` (default bfloat16) to `extract_experts.py` and `merge_experts.py` so a cartridge round-trip is bit-exact. Needed for the 26B cartridge round-trip validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)