### PR TITLE
chore: ruff config + lint fixes (#33)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,22 @@ dependencies = [
 [project.optional-dependencies]
 analysis = ["matplotlib", "seaborn", "pandas"]
 data = ["datasets"]
-dev = ["pytest"]
+dev = ["pytest", "ruff"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/exex"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+extend-exclude = ["scripts/generate_report.py"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "B", "UP", "SIM"]
+ignore = ["E501", "E741"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["E402", "B007", "B017"]

--- a/scripts/manage_expert.py
+++ b/scripts/manage_expert.py
@@ -10,30 +10,30 @@ def main():
     parser = argparse.ArgumentParser(description="Add, remove, or label experts in a MoE model checkpoint.")
     parser.add_argument("--model_path", type=str, required=True, help="Path to the input model checkpoint")
     parser.add_argument("--output_dir", type=str, required=True, help="Path to save the modified model")
-    
+
     subparsers = parser.add_subparsers(dest="action", help="Action to perform", required=True)
-    
+
     # Remove expert parser
     parser_remove = subparsers.add_parser("remove", help="Remove an expert from the model")
     parser_remove.add_argument("--expert_index", type=int, required=True, help="Index of the expert to remove")
-    
+
     # Add expert parser
     parser_add = subparsers.add_parser("add", help="Add a new expert to the model (cloned from an existing slot)")
     parser_add.add_argument("--clone_from", type=int, default=0, help="Source expert index to clone")
     parser_add.add_argument("--label", type=str, default=None, help="Label to give to the new expert")
-    
+
     # Label expert parser
     parser_label = subparsers.add_parser("label", help="Add or update a label for an existing expert")
     parser_label.add_argument("--expert_index", type=int, required=True, help="Index of the expert to label")
     parser_label.add_argument("--label_name", type=str, required=True, help="The label name")
-    
+
     args = parser.parse_args()
-    
+
     manager = ExpertManager(args.model_path)
-    
+
     if args.action == "remove":
         manager.remove_expert(args.expert_index, args.output_dir)
-        
+
     elif args.action == "add":
         new_idx = manager.clone_expert(args.clone_from, label=args.label)
         print(f"Cloned expert {args.clone_from} -> new slot {new_idx}")

--- a/scripts/run_analysis.py
+++ b/scripts/run_analysis.py
@@ -27,11 +27,11 @@ def main():
     parser.add_argument("--model_path", type=str, required=True, help="Path to the MoE model (local or HF hub)")
     parser.add_argument("--dataset_path", type=str, default=None, help="Path to HF dataset. Uses dummy data if not provided.")
     parser.add_argument("--max_samples", type=int, default=50, help="Max samples per domain to analyze")
-    
+
     args = parser.parse_args()
-    
+
     analyzer = RoutingAnalyzer(args.model_path)
-    
+
     if args.dataset_path:
         from datasets import load_dataset
         dataset = load_dataset(args.dataset_path, split="train")
@@ -39,14 +39,14 @@ def main():
     else:
         print("No dataset provided, using internal multi-domain dummy dataset...")
         dataset = create_dummy_dataset()
-        
+
     results = analyzer.analyze_dataset(
-        dataset, 
-        text_col="text", 
-        domain_col="domain", 
+        dataset,
+        text_col="text",
+        domain_col="domain",
         max_samples_per_domain=args.max_samples
     )
-    
+
     analyzer.print_associations(results)
     analyzer.find_correlations(results, threshold_ratio=0.75)
 

--- a/src/exex/analyzer.py
+++ b/src/exex/analyzer.py
@@ -6,11 +6,12 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from tqdm import tqdm
 
 class RoutingAnalyzer:
-    def __init__(self, model_path, device="cuda" if torch.cuda.is_available() else "cpu"):
-        self.device = device
+    def __init__(self, model_path, device=None):
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        device = self.device
         self.tokenizer = AutoTokenizer.from_pretrained(model_path)
         self.model = AutoModelForCausalLM.from_pretrained(
-            model_path, 
+            model_path,
             device_map=device,
             output_router_logits=True,
             torch_dtype=torch.float16 if device == "cuda" else torch.float32
@@ -23,61 +24,61 @@ class RoutingAnalyzer:
         self.num_layers = self.arch.num_layers
         self.num_experts = self.arch.num_experts
         self.top_k = self.arch.top_k
-        
+
     @torch.no_grad()
     def analyze_dataset(self, dataset, text_col="text", domain_col="domain", max_samples_per_domain=100):
         """
         Analyzes router behavior over a multi-domain dataset.
         Returns matrices for expert-domain association and expert co-occurrence.
         """
-        domain_counts = defaultdict(int)
-        
+        defaultdict(int)
+
         # We track how many times each expert was selected per layer per domain
         # shape: (num_layers, num_experts)
         domain_expert_activations = defaultdict(lambda: np.zeros((self.num_layers, self.num_experts)))
-        
+
         # We track co-occurrence of experts within the same token routing decision
         # shape: (num_layers, num_experts, num_experts)
         co_occurrence = np.zeros((self.num_layers, self.num_experts, self.num_experts))
         total_tokens_per_domain = defaultdict(int)
-        
+
         self.model.eval()
-        
+
         # Organize dataset by domain to easily enforce max_samples_per_domain
         domain_data = defaultdict(list)
         for row in dataset:
             domain = row[domain_col]
             if len(domain_data[domain]) < max_samples_per_domain:
                 domain_data[domain].append(row[text_col])
-                
+
         for domain, texts in domain_data.items():
             print(f"Analyzing domain: {domain}")
             for text in tqdm(texts, desc=f"Processing {domain}"):
                 inputs = self.tokenizer(text, return_tensors="pt", truncation=True, max_length=512).to(self.device)
-                
+
                 # Forward pass
                 outputs = self.model(**inputs)
-                
+
                 # router_logits is a tuple of (batch_size, sequence_length, num_experts)
                 router_logits = outputs.router_logits
-                
+
                 seq_len = inputs.input_ids.shape[1]
                 total_tokens_per_domain[domain] += seq_len
-                
+
                 for layer_idx, logits in enumerate(router_logits):
                     # probabilities -> (1, seq_len, num_experts)
                     probs = torch.softmax(logits, dim=-1)
-                    
+
                     # Top-k indices -> (1, seq_len, top_k)
                     top_k_indices = torch.topk(probs, self.top_k, dim=-1).indices
-                    
+
                     # Flatten batch and seq length -> (seq_len, top_k)
                     top_k_indices = top_k_indices.view(-1, self.top_k).cpu().numpy()
-                    
+
                     for token_experts in top_k_indices:
                         for exp_idx in token_experts:
                             domain_expert_activations[domain][layer_idx, exp_idx] += 1
-                            
+
                         # Update co-occurrence matrix for pairs (combinations of 2)
                         for exp_i, exp_j in itertools.combinations(token_experts, 2):
                             co_occurrence[layer_idx, exp_i, exp_j] += 1
@@ -89,24 +90,24 @@ class RoutingAnalyzer:
             "total_tokens_per_domain": dict(total_tokens_per_domain)
         }
         return results
-        
+
     def print_associations(self, results):
         """Identifies which experts are most associated with which domains."""
         activations = results["domain_expert_activations"]
         tokens = results["total_tokens_per_domain"]
-        
+
         print("\n--- Expert-Domain Associations ---")
-        for domain in activations.keys():
+        for domain in activations:
             # Average activations per token for this domain
             avg_act = activations[domain] / tokens[domain]
-            
+
             print(f"\nDomain: {domain} (Tokens: {tokens[domain]})")
             for layer in range(self.num_layers):
                 # Find top 3 experts for this layer and domain
                 top_experts = np.argsort(avg_act[layer])[::-1][:3]
-                print(f"  Layer {layer:02d} Top Experts: " + 
+                print(f"  Layer {layer:02d} Top Experts: " +
                       ", ".join([f"E{e} ({avg_act[layer, e]:.3f}/tok)" for e in top_experts]))
-                      
+
     def find_correlations(self, results, threshold_ratio=0.8):
         """
         Identifies block-wise expert correlations.
@@ -114,29 +115,29 @@ class RoutingAnalyzer:
         """
         print("\n--- Block-wise Expert Correlations ---")
         co_occurrence = results["co_occurrence"]
-        
+
         # We need the marginal activations to calculate P(A|B) and P(B|A)
         # We can approximate marginals from the diagonal of co-occurrence if we tracked it,
         # or we can reconstruct it from domain_expert_activations.
         total_activations = np.zeros((self.num_layers, self.num_experts))
         for counts in results["domain_expert_activations"].values():
             total_activations += counts
-            
+
         for layer in range(self.num_layers):
             layer_co = co_occurrence[layer]
             layer_act = total_activations[layer]
-            
+
             correlations_found = False
             for i in range(self.num_experts):
                 for j in range(i + 1, self.num_experts):
                     if layer_co[i, j] == 0:
                         continue
-                        
+
                     # Probability of seeing j given i is selected
                     p_j_given_i = layer_co[i, j] / layer_act[i] if layer_act[i] > 0 else 0
                     # Probability of seeing i given j is selected
                     p_i_given_j = layer_co[i, j] / layer_act[j] if layer_act[j] > 0 else 0
-                    
+
                     if p_j_given_i >= threshold_ratio and p_i_given_j >= threshold_ratio:
                         if not correlations_found:
                             print(f"\nLayer {layer:02d}:")

--- a/src/exex/cartridge.py
+++ b/src/exex/cartridge.py
@@ -21,7 +21,6 @@ JSON-encoded) carries:
 
 import json
 
-import torch
 from safetensors.torch import save_file, load_file
 
 from exex.arch import MoEArch, iter_moe_layers

--- a/src/exex/merger.py
+++ b/src/exex/merger.py
@@ -5,7 +5,6 @@ Supports transplanting into an existing slot (with optional alpha blending
 against the incumbent weights) or growing a fresh slot via ExpertManager.
 """
 
-import torch
 
 from exex.arch import MoEArch, iter_moe_layers
 from exex.cartridge import Cartridge, load_cartridge

--- a/tests/test_cartridge.py
+++ b/tests/test_cartridge.py
@@ -1,4 +1,3 @@
-import json
 
 import pytest
 import torch

--- a/tests/test_pruner.py
+++ b/tests/test_pruner.py
@@ -1,7 +1,6 @@
 import pytest
 import torch
 
-from exex.arch import MoEArch
 from exex.pruner import (
     collect_router_stats,
     score_experts,


### PR DESCRIPTION
Closes #33. Adds `[tool.ruff]` (E,F,W,B,UP,SIM; line-length 100), `ruff` in the dev extra, auto-fixes whitespace/unused imports, fixes the `cuda.is_available()` default-arg and unused variable in analyzer.py. generate_report.py excluded (mock-only, slated for #27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)