### PR TITLE
fix(pruner): implement real REAP saliency, rename old proxy to gate_weight_norm (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ python scripts/prune_experts.py \
   --output_dir ./checkpoints/pruned
 ```
 
-Strategies: `utilisation` (routing frequency), `magnitude` (weight norm), `reap` (router gate mass × weight norm, after [arXiv:2510.13999](https://arxiv.org/abs/2510.13999)). `--mode zero` zeroes weights in place for sparse runtimes instead of shrinking the model.
+Strategies: `utilisation` (routing frequency), `magnitude` (weight norm), `reap` (Router-weighted Expert Activation Pruning, [arXiv:2510.13999](https://arxiv.org/abs/2510.13999): mean over routed calibration tokens of router weight × L2 norm of the expert's output), `gate_weight_norm` (the cheaper router gate mass × weight norm proxy that was previously labelled `reap`). `--mode zero` zeroes weights in place for sparse runtimes instead of shrinking the model.
 
 ### Analyze routing (currently broken on transformers 5 — see #27)
 

--- a/scripts/prune_experts.py
+++ b/scripts/prune_experts.py
@@ -11,6 +11,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from exex.pruner import (
+    STRATEGIES,
     collect_router_stats,
     score_experts,
     select_prune_candidates,
@@ -35,9 +36,14 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model_path", required=True)
     parser.add_argument("--strategy", default="reap",
-                        choices=["utilisation", "magnitude", "reap"])
+                        choices=list(STRATEGIES),
+                        help="reap: router-weighted expert activation norm "
+                             "(arXiv:2510.13999); gate_weight_norm: gate mass "
+                             "x weight norm proxy; utilisation: routing "
+                             "frequency; magnitude: weight norm")
     parser.add_argument("--calibration_dataset",
-                        help="HF dataset (needed for utilisation/reap)")
+                        help="HF dataset or local JSON file (needed for "
+                             "utilisation/reap/gate_weight_norm)")
     parser.add_argument("--text_column", default="text")
     parser.add_argument("--max_samples", type=int, default=128)
     parser.add_argument("--max_length", type=int, default=512)
@@ -59,7 +65,7 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained(args.model_path)
 
     stats = None
-    if args.strategy in ("utilisation", "reap"):
+    if args.strategy in ("utilisation", "reap", "gate_weight_norm"):
         if not args.calibration_dataset:
             parser.error(f"--strategy {args.strategy} requires --calibration_dataset")
         print("Collecting router statistics...")
@@ -69,6 +75,7 @@ def main():
                 args.calibration_dataset, tokenizer,
                 args.text_column, args.max_samples, args.max_length,
             ),
+            activation_norms=args.strategy == "reap",
         )
 
     scores = score_experts(model, args.strategy, stats=stats)

--- a/src/exex/pruner.py
+++ b/src/exex/pruner.py
@@ -2,10 +2,16 @@
 Expert pruning: score experts on a calibration set, then remove or zero them.
 
 Strategies:
-    utilisation — mean routing selection frequency (drop the rarely-picked)
-    magnitude   — L2 norm of expert weights (drop the smallest)
-    reap        — router gate mass x expert weight norm (REAP-style proxy;
-                  see arXiv:2510.13999)
+    utilisation      — mean routing selection frequency (drop the rarely-picked)
+    magnitude        — L2 norm of expert weights (drop the smallest)
+    reap             — Router-weighted Expert Activation Pruning
+                       (arXiv:2510.13999): mean over the calibration tokens
+                       routed to expert e of g_e(x) * ||f_e(x)||_2, where g_e
+                       is the (normalised, per-expert-scaled) router weight and
+                       f_e(x) the expert's output for that token. Needs
+                       ``collect_router_stats(..., activation_norms=True)``.
+    gate_weight_norm — router gate mass x expert weight norm (the cheap proxy
+                       that used to be called "reap")
 """
 
 import torch
@@ -13,7 +19,8 @@ import torch
 from exex.arch import MoEArch, iter_moe_layers
 from exex.manager import ExpertManager
 
-STRATEGIES = ("utilisation", "magnitude", "reap")
+STRATEGIES = ("utilisation", "magnitude", "reap", "gate_weight_norm")
+_NEEDS_STATS = ("utilisation", "reap", "gate_weight_norm")
 
 
 class RouterStats:
@@ -22,6 +29,10 @@ class RouterStats:
     def __init__(self, num_layers, num_experts):
         self.counts = torch.zeros(num_layers, num_experts)
         self.gate_mass = torch.zeros(num_layers, num_experts)
+        # sum over routed tokens of g_e(x) * ||f_e(x)||_2 (REAP saliency);
+        # only filled when collected with ``activation_norms=True``
+        self.activation_saliency = torch.zeros(num_layers, num_experts)
+        self.has_activation_saliency = False
         self.tokens = 0
 
     @property
@@ -29,17 +40,50 @@ class RouterStats:
         """Fraction of tokens that routed to each expert, per layer [L, E]."""
         return self.counts / max(self.tokens, 1)
 
+    @property
+    def mean_saliency(self):
+        """Mean REAP saliency per routed token, per layer [L, E]."""
+        return self.activation_saliency / self.counts.clamp(min=1)
+
+
+def expert_output_norms(experts, hidden_states, expert_idx):
+    """L2 norm of expert ``expert_idx``'s output for each row of
+    ``hidden_states`` [T, H] -> [T]. Recomputed from the raw fused tensors so
+    it also works when the experts' forward has been patched by surgery."""
+    gate_up = experts.gate_up_proj.data[expert_idx]
+    down = experts.down_proj.data[expert_idx]
+    x = hidden_states.to(gate_up.dtype)
+    gate, up = torch.nn.functional.linear(x, gate_up).chunk(2, dim=-1)
+    out = torch.nn.functional.linear(experts.act_fn(gate) * up, down)
+    return out.float().norm(dim=-1)
+
+
+def _activation_saliency(experts, hidden_states, top_k_index, top_k_weights):
+    """Per-expert sum over routed tokens of g_e(x) * ||f_e(x)||_2 -> [E]."""
+    num_experts = experts.gate_up_proj.shape[0]
+    saliency = torch.zeros(num_experts)
+    for expert_idx in torch.unique(top_k_index).tolist():
+        token_idx, top_k_pos = torch.where(top_k_index == expert_idx)
+        norms = expert_output_norms(experts, hidden_states[token_idx], expert_idx)
+        gate = top_k_weights[token_idx, top_k_pos].float()
+        saliency[expert_idx] = (gate * norms).sum().cpu()
+    return saliency
+
 
 @torch.no_grad()
-def collect_router_stats(model, batches):
+def collect_router_stats(model, batches, activation_norms=False):
     """Run calibration batches and capture routing decisions via hooks.
 
     Args:
         batches: iterable of dicts with at least ``input_ids``
+        activation_norms: also accumulate the REAP activation saliency
+            g_e(x) * ||f_e(x)||_2 per expert (needs an extra expert forward
+            per hit expert; required by the ``"reap"`` strategy)
     """
     arch = MoEArch.from_model(model)
     moe_layers = list(iter_moe_layers(model))
     stats = RouterStats(len(moe_layers), arch.num_experts)
+    stats.has_activation_saliency = activation_norms
 
     handles = []
     for pos, (_, layer) in enumerate(moe_layers):
@@ -53,6 +97,15 @@ def collect_router_stats(model, batches):
             stats.gate_mass[_pos].index_add_(0, flat_idx.cpu(), flat_w)
 
         handles.append(layer.router.register_forward_hook(hook))
+
+        if activation_norms:
+            def experts_hook(module, args, output, _pos=pos):
+                hidden_states, top_k_index, top_k_weights = args
+                stats.activation_saliency[_pos] += _activation_saliency(
+                    module, hidden_states, top_k_index, top_k_weights
+                )
+
+            handles.append(layer.experts.register_forward_hook(experts_hook))
 
     model.eval()
     try:
@@ -81,14 +134,21 @@ def score_experts(model, strategy, stats=None):
     """Score every expert; lower score == better prune candidate. Returns [E]."""
     if strategy not in STRATEGIES:
         raise ValueError(f"Unknown strategy {strategy!r} (choose from {STRATEGIES})")
-    if strategy in ("utilisation", "reap") and stats is None:
+    if strategy in _NEEDS_STATS and stats is None:
         raise ValueError(f"strategy {strategy!r} requires collected RouterStats")
 
     if strategy == "utilisation":
         return stats.selection_freq.mean(dim=0)
     if strategy == "magnitude":
         return weight_norms(model)
-    # reap: mean gate mass per token, weighted by expert weight norm
+    if strategy == "reap":
+        if not stats.has_activation_saliency:
+            raise ValueError(
+                "strategy 'reap' requires RouterStats collected with "
+                "activation_norms=True"
+            )
+        return stats.mean_saliency.mean(dim=0)
+    # gate_weight_norm: mean gate mass per token, weighted by expert weight norm
     gate = stats.gate_mass.sum(dim=0) / max(stats.tokens, 1)
     return gate * weight_norms(model)
 

--- a/tests/test_pruner.py
+++ b/tests/test_pruner.py
@@ -3,6 +3,7 @@ import torch
 
 from exex.pruner import (
     collect_router_stats,
+    expert_output_norms,
     score_experts,
     select_prune_candidates,
     prune_experts,
@@ -11,7 +12,9 @@ from exex.pruner import (
 
 @pytest.fixture
 def stats(tiny_gemma4_moe, sample_batch):
-    return collect_router_stats(tiny_gemma4_moe, [sample_batch])
+    return collect_router_stats(
+        tiny_gemma4_moe, [sample_batch], activation_norms=True
+    )
 
 
 class TestCollect:
@@ -22,17 +25,103 @@ class TestCollect:
         assert stats.counts.sum(dim=1).tolist() == [64.0, 64.0]
         assert (stats.gate_mass >= 0).all()
 
+    def test_activation_saliency_shape_and_sign(self, stats):
+        assert stats.has_activation_saliency
+        assert stats.activation_saliency.shape == (2, 4)
+        assert (stats.activation_saliency >= 0).all()
+        assert (stats.activation_saliency > 0).any()
+        assert stats.mean_saliency.shape == (2, 4)
+
+    def test_saliency_off_by_default(self, tiny_gemma4_moe, sample_batch):
+        s = collect_router_stats(tiny_gemma4_moe, [sample_batch])
+        assert not s.has_activation_saliency
+        assert (s.activation_saliency == 0).all()
+
+    def test_zeroed_expert_has_zero_saliency(self, tiny_gemma4_moe, sample_batch):
+        with torch.no_grad():
+            for layer in tiny_gemma4_moe.model.layers:
+                layer.experts.gate_up_proj.data[1].zero_()
+                layer.experts.down_proj.data[1].zero_()
+        s = collect_router_stats(
+            tiny_gemma4_moe, [sample_batch], activation_norms=True
+        )
+        # zeroing weights does not touch the router: expert 1 is still routed to
+        assert (s.counts[:, 1] > 0).all()
+        assert (s.activation_saliency[:, 1] == 0).all()
+        others = [e for e in range(4) if e != 1]
+        assert (s.activation_saliency[:, others] > 0).any()
+
+    def test_saliency_matches_manual_recomputation(self, tiny_gemma4_moe, sample_batch):
+        model = tiny_gemma4_moe
+        captured = []
+
+        def grab(module, args, output):
+            captured.append(tuple(a.detach().clone() for a in args))
+
+        handles = [
+            layer.experts.register_forward_hook(grab)
+            for layer in model.model.layers
+        ]
+        try:
+            s = collect_router_stats(model, [sample_batch], activation_norms=True)
+        finally:
+            for h in handles:
+                h.remove()
+        assert len(captured) == 2
+
+        for pos, (hidden, top_k_index, top_k_weights) in enumerate(captured):
+            experts = model.model.layers[pos].experts
+            expected = torch.zeros(4)
+            expected_counts = torch.zeros(4)
+            for t in range(hidden.shape[0]):
+                for k in range(top_k_index.shape[1]):
+                    e = int(top_k_index[t, k])
+                    g = top_k_weights[t, k].float()
+                    x = hidden[t]
+                    gate, up = (experts.gate_up_proj[e] @ x).chunk(2)
+                    f = experts.down_proj[e] @ (experts.act_fn(gate) * up)
+                    expected[e] += g * f.norm()
+                    expected_counts[e] += 1
+                    # helper agrees with the by-hand expert output norm
+                    torch.testing.assert_close(
+                        expert_output_norms(experts, x[None], e)[0], f.norm(),
+                        rtol=1e-4, atol=1e-5,
+                    )
+            torch.testing.assert_close(
+                s.activation_saliency[pos], expected, rtol=1e-4, atol=1e-5
+            )
+            torch.testing.assert_close(s.counts[pos], expected_counts)
+
 
 class TestScores:
     def test_all_strategies(self, tiny_gemma4_moe, stats):
-        for strategy in ("utilisation", "magnitude", "reap"):
+        for strategy in ("utilisation", "magnitude", "reap", "gate_weight_norm"):
             scores = score_experts(tiny_gemma4_moe, strategy, stats=stats)
             assert scores.shape == (4,)
             assert torch.isfinite(scores).all()
 
     def test_stats_required(self, tiny_gemma4_moe):
-        with pytest.raises(ValueError):
-            score_experts(tiny_gemma4_moe, "utilisation")
+        for strategy in ("utilisation", "reap", "gate_weight_norm"):
+            with pytest.raises(ValueError):
+                score_experts(tiny_gemma4_moe, strategy)
+
+    def test_reap_requires_activation_norms(self, tiny_gemma4_moe, sample_batch):
+        s = collect_router_stats(tiny_gemma4_moe, [sample_batch])
+        with pytest.raises(ValueError, match="activation_norms"):
+            score_experts(tiny_gemma4_moe, "reap", stats=s)
+
+    def test_reap_is_mean_saliency_over_layers(self, tiny_gemma4_moe, stats):
+        scores = score_experts(tiny_gemma4_moe, "reap", stats=stats)
+        expected = (stats.activation_saliency / stats.counts.clamp(min=1)).mean(dim=0)
+        torch.testing.assert_close(scores, expected)
+        assert (scores >= 0).all()
+
+    def test_reap_differs_from_gate_weight_norm(self, tiny_gemma4_moe, stats):
+        reap = score_experts(tiny_gemma4_moe, "reap", stats=stats)
+        proxy = score_experts(tiny_gemma4_moe, "gate_weight_norm", stats=stats)
+        assert not torch.allclose(reap, proxy)
+        # also not merely a rescaling of the proxy
+        assert not torch.allclose(reap / reap.sum(), proxy / proxy.sum())
 
 
 class TestSelect:


### PR DESCRIPTION
## Summary

`score_experts(model, "reap", stats)` previously returned router gate mass × expert **weight** L2 norm, which is not REAP. This PR implements REAP (arXiv:2510.13999, Router-weighted Expert Activation Pruning) properly and keeps the old proxy under a new name.

- `RouterStats.activation_saliency` `[L, E]`: sum over calibration tokens routed to expert e of `g_e(x) * ||f_e(x)||_2`; `mean_saliency` = saliency / max(counts, 1); `has_activation_saliency` flag.
- `collect_router_stats(model, batches, activation_norms=False)`: when `True`, registers a forward hook on `layer.experts` that recomputes per-token expert output norms from the raw `gate_up_proj` / `down_proj` tensors (`act_fn(gate) * up` then `down`) for hit experts only, under `no_grad`. Uses the raw tensors so it also works when exex surgery has patched `experts.forward`.
- `score_experts(..., "reap")` returns mean saliency per expert averaged over layers (consistent with the other strategies) and raises a clear `ValueError` when stats were collected without `activation_norms=True`.
- Old behaviour available as strategy `"gate_weight_norm"`; `STRATEGIES` and module docstring updated.
- `scripts/prune_experts.py`: `--strategy` choices from `STRATEGIES`, help text, passes `activation_norms=True` for reap (default strategy unchanged).
- README "Prune experts" paragraph corrected and mentions the renamed proxy.

## Tests

New tests in `tests/test_pruner.py` (tiny Gemma4 MoE fixture, 4 experts, 2 layers, top-2):
- saliency shape `[2, 4]` and non-negative; zero when not requested
- expert with zeroed weights gets saliency exactly 0 while still being routed to
- hooked saliency matches a by-hand recomputation from the expert weights for one batch (also checks `expert_output_norms` helper)
- `reap` differs from `gate_weight_norm` (and is not a rescaling of it)
- `reap` requires `activation_norms=True`; stats-required errors for all stats strategies

`.venv/bin/python -m pytest -q tests`: 73 passed. `uvx ruff check` clean on touched files (3 pre-existing SIM findings remain in untouched `merge_experts.py`, `train_expert.py`, `trainer.py`).

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)