### PR TITLE
feat: --top_k eval override; cache-friendly clone_expert

### DIFF
--- a/scripts/eval_perplexity.py
+++ b/scripts/eval_perplexity.py
@@ -28,11 +28,14 @@ def main():
                              "per-expert token counts under no_grad")
     parser.add_argument("--cartridge", action="append", default=[],
                         help="Install before eval: path[:expert[:target_index|new]]; repeatable")
+    parser.add_argument("--top_k", type=int, default=None,
+                        help="Override active experts per token at eval (A4B -> AxB knob)")
     parser.add_argument("--output", default=None, help="Write JSON result here")
     args = parser.parse_args()
 
     model, tokenizer = load_model(args.model_path, dtype=args.dtype,
-                                  experts_impl=args.experts_impl, cartridges=args.cartridge)
+                                  experts_impl=args.experts_impl, cartridges=args.cartridge,
+                                  top_k=args.top_k)
 
     texts = load_texts(args.dataset, args.text_column, args.max_samples)
     ppl, n_tokens = perplexity(model, tokenizer, texts, max_length=args.max_length)
@@ -40,6 +43,7 @@ def main():
     result = {
         "model": args.model_path,
         "cartridges": args.cartridge,
+        "top_k": args.top_k,
         "dataset": args.dataset,
         "num_texts": len(texts),
         "num_tokens": n_tokens,

--- a/scripts/router_stats.py
+++ b/scripts/router_stats.py
@@ -28,11 +28,14 @@ def main():
                              "per-expert token counts under no_grad")
     parser.add_argument("--cartridge", action="append", default=[],
                         help="Install before eval: path[:expert[:target_index|new]]; repeatable")
+    parser.add_argument("--top_k", type=int, default=None,
+                        help="Override active experts per token at eval (A4B -> AxB knob)")
     parser.add_argument("--output", default=None, help="Write JSON result here")
     args = parser.parse_args()
 
     model, tokenizer = load_model(args.model_path, dtype=args.dtype,
-                                  experts_impl=args.experts_impl, cartridges=args.cartridge)
+                                  experts_impl=args.experts_impl, cartridges=args.cartridge,
+                                  top_k=args.top_k)
 
     from datasets import load_dataset
     if os.path.isfile(args.dataset):
@@ -53,6 +56,7 @@ def main():
     result = {
         "model": args.model_path,
         "cartridges": args.cartridge,
+        "top_k": args.top_k,
         "dataset": args.dataset,
         "tokens": stats.tokens,
         "num_experts": arch.num_experts,

--- a/src/exex/loading.py
+++ b/src/exex/loading.py
@@ -49,9 +49,32 @@ def install_cartridges(model, specs):
     return landed
 
 
+def set_top_k(model, top_k):
+    """Override active experts per token at inference (no retraining).
+
+    Gemma 4 routers read ``config.top_k_experts`` at forward time, so this is
+    a pure config knob: 26B-A4B becomes roughly A{4*k/8}B. Returns previous k.
+    """
+    from exex.arch import MoEArch, iter_moe_layers
+
+    arch = MoEArch.from_model(model)
+    if not 1 <= top_k <= arch.num_experts:
+        raise ValueError(f"top_k {top_k} out of range 1..{arch.num_experts}")
+    previous = arch.top_k
+    cfg = getattr(model.config, "text_config", None) or model.config
+    setattr(cfg, arch.top_k_key, top_k)
+    for _, layer in iter_moe_layers(model):
+        rcfg = getattr(layer.router, "config", None)
+        if rcfg is not None:
+            setattr(rcfg, arch.top_k_key, top_k)
+    return previous
+
+
 def load_model(model_path, dtype="bfloat16", device_map="auto",
-               experts_impl=None, cartridges=(), eval_mode=True):
-    """Load model (+tokenizer) and install cartridges. Returns (model, tokenizer)."""
+               experts_impl=None, cartridges=(), eval_mode=True, top_k=None):
+    """Load model (+tokenizer), install cartridges, optionally override top-k.
+
+    Returns (model, tokenizer)."""
     kwargs = {"dtype": getattr(torch, dtype) if isinstance(dtype, str) else dtype,
               "device_map": device_map}
     if experts_impl:
@@ -61,6 +84,9 @@ def load_model(model_path, dtype="bfloat16", device_map="auto",
         with torch.no_grad():
             landed = install_cartridges(model, cartridges)
         print(f"Installed cartridge experts at indices: {landed}")
+    if top_k is not None:
+        prev = set_top_k(model, top_k)
+        print(f"Router top-k overridden: {prev} -> {top_k}")
     if eval_mode:
         model.eval()
     tokenizer = AutoTokenizer.from_pretrained(model_path)

--- a/src/exex/manager.py
+++ b/src/exex/manager.py
@@ -40,29 +40,31 @@ class ExpertManager:
             )
         for _, layer in iter_moe_layers(self.model):
             experts = layer.experts
+            router = layer.router
 
-            # Expand fused expert tensors
-            source_gate_up = experts.gate_up_proj.data[source_idx:source_idx+1].clone()
-            experts.gate_up_proj = nn.Parameter(
-                torch.cat([experts.gate_up_proj.data, source_gate_up], dim=0)
-            )
-            source_down = experts.down_proj.data[source_idx:source_idx+1].clone()
-            experts.down_proj = nn.Parameter(
-                torch.cat([experts.down_proj.data, source_down], dim=0)
-            )
+            # Grow each fused tensor by one slot. Allocate the new tensor,
+            # copy, drop the old one and release its cached CUDA blocks
+            # before the next layer: with the old cat() pattern every freed
+            # block was too small to be reused, so reserved memory doubled
+            # (89 GB vs 68 GB at 26B, job 2175641).
+            def grown(param):
+                old = param.data
+                new = old.new_empty((old.shape[0] + 1, *old.shape[1:]))
+                new[:-1].copy_(old)
+                new[-1].copy_(old[source_idx])
+                return nn.Parameter(new, requires_grad=param.requires_grad)
+
+            experts.gate_up_proj = grown(experts.gate_up_proj)
+            experts.down_proj = grown(experts.down_proj)
             experts.num_experts += 1
 
-            # Expand router
-            router = layer.router
-            source_row = router.proj.weight.data[source_idx:source_idx+1].clone()
-            new_weight = torch.cat([router.proj.weight.data, source_row], dim=0)
-            router.proj = nn.Linear(new_weight.shape[1], new_weight.shape[0], bias=False)
-            router.proj.weight = nn.Parameter(new_weight)
-
-            source_scale = router.per_expert_scale.data[source_idx:source_idx+1].clone()
-            router.per_expert_scale = nn.Parameter(
-                torch.cat([router.per_expert_scale.data, source_scale], dim=0)
-            )
+            new_weight = grown(router.proj.weight)
+            router.proj = nn.Linear(new_weight.shape[1], new_weight.shape[0], bias=False,
+                                    device="meta")
+            router.proj.weight = new_weight
+            router.per_expert_scale = grown(router.per_expert_scale)
+            if torch.cuda.is_available() and new_weight.is_cuda:
+                torch.cuda.empty_cache()
 
         self.arch.num_experts += 1
         self.arch.sync_config(self.config)

--- a/tests/test_training_loop.py
+++ b/tests/test_training_loop.py
@@ -75,3 +75,19 @@ class TestCartridgeLoading:
             assert torch.equal(layer.experts.gate_up_proj.data[2],
                                donor.model.layers[0].experts.gate_up_proj.data[2]) or True
         assert install_cartridges(copy.deepcopy(base), [f"{path}:e2:new"]) == [4]
+
+
+class TestTopKOverride:
+    def test_set_top_k_changes_active_experts(self, tiny_gemma4_moe, sample_batch):
+        from exex.loading import set_top_k
+        from exex.pruner import collect_router_stats
+
+        model = tiny_gemma4_moe.eval()
+        batches = [{"input_ids": sample_batch["input_ids"]}]
+        s2 = collect_router_stats(model, batches)
+        assert set_top_k(model, 3) == 2
+        s3 = collect_router_stats(model, batches)
+        # every token selects exactly k experts per layer
+        assert torch.allclose(s2.counts.sum(dim=1), torch.full((2,), 2.0 * s2.tokens))
+        assert torch.allclose(s3.counts.sum(dim=1), torch.full((2,), 3.0 * s3.tokens))
+        assert model.config.top_k_experts == 3


### PR DESCRIPTION
Adds `exex.loading.set_top_k` and `--top_k` on `eval_perplexity.py` / `router_stats.py` for on-the-fly active-parameter sweeps (Markus's request via ruler, 2026-09-07). Rewrites `clone_expert` allocation to avoid the reserved-VRAM doubling seen in the 26B clone arm. Test: routing stats select exactly k experts per token after override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)