### PR TITLE
fix(analyzer): rebuild RoutingAnalyzer on router forward hooks for transformers 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ python scripts/prune_experts.py \
 
 Strategies: `utilisation` (routing frequency), `magnitude` (weight norm), `reap` (Router-weighted Expert Activation Pruning, [arXiv:2510.13999](https://arxiv.org/abs/2510.13999): mean over routed calibration tokens of router weight × L2 norm of the expert's output), `gate_weight_norm` (the cheaper router gate mass × weight norm proxy that was previously labelled `reap`). `--mode zero` zeroes weights in place for sparse runtimes instead of shrinking the model.
 
-### Analyze routing (currently broken on transformers 5 — see #27)
+### Analyze routing
 
 ```bash
 python scripts/run_analysis.py --model_path ... --dataset_path your/multidomain-data
-python scripts/generate_report.py --model_path ... --output_dir report/
+python scripts/generate_report.py --model_path ... --output_dir report/   # or --model_path mock
 ```
 
 Produces expert–domain activation maps, co-occurrence heatmaps, cross-layer expert pipelines, and suggested expert labels.
@@ -140,7 +140,7 @@ Only the trained expert views and router carry gradients and optimizer state; ev
 
 **Validated end-to-end on Gemma 4 26B A4B** (single GH200, bf16): training expert 42 for 500 steps on PubMedQA cut held-out domain perplexity by **11.3%** with general perplexity flat (−0.09% on wikitext-2), stable-to-rising router allocation for the trained expert, and KL ≈ 1e-4 throughout — no routing collapse. Details in [#10](https://github.com/marksverdhei/exex/issues/10). Peak training VRAM ~58 GB at batch size 1, seq 512, full bf16 (no quantization). The extracted cartridge (341 MB) reproduces the trained checkpoint's expert tensors bit-exactly, and merging it into a fresh base reproduces its perplexity (4.7034 vs 4.7028). Caveat: train and eval there share one QA template; format-vs-domain controls are in progress.
 
-A candid state-of-the-repo audit lives in [`docs/AUDIT-2026-09-07.md`](docs/AUDIT-2026-09-07.md). Known broken: the routing analyzer (`run_analysis.py`, [#27](https://github.com/marksverdhei/exex/issues/27)).
+A candid state-of-the-repo audit lives in [`docs/AUDIT-2026-09-07.md`](docs/AUDIT-2026-09-07.md).
 
 Inference note: the fused grouped-GEMM MoE kernel currently asserts on Hopper for `no_grad` forwards with unaligned per-expert token counts; eval/calibration CLIs default to `--experts_impl eager` ([#21](https://github.com/marksverdhei/exex/pull/21)).
 

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -1,12 +1,24 @@
-import os
+"""
+Generate a Markdown + plots routing report for an MoE model.
+
+Both the real-model path and ``--model_path mock`` run through
+``exex.analyzer.RoutingAnalyzer`` (forward hooks on each ``layer.router``), so
+the report code is exercised identically in both cases. Plotting deps
+(matplotlib / seaborn, the ``analysis`` extra) are imported lazily.
+"""
+
 import argparse
-import torch
+import os
+import sys
+from types import SimpleNamespace
+
 import numpy as np
-import pandas as pd
-import matplotlib.pyplot as plt
-import seaborn as sns
-from collections import defaultdict
-from tqdm import tqdm
+import torch
+from torch import nn
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from exex.analyzer import RoutingAnalyzer  # noqa: E402
+
 
 def create_nordic_dataset():
     """
@@ -26,315 +38,248 @@ def create_nordic_dataset():
         {"text": "Photosynthesis is the process by which plants use sunlight to synthesize nutrients.", "domain": "stem"},
         {"text": "The mitochondria is the powerhouse of the cell.", "domain": "stem"},
         {"text": "def quicksort(arr):\n    if len(arr) <= 1: return arr\n    pivot = arr[0]\n    return quicksort([x for x in arr[1:] if x < pivot]) + [pivot] + quicksort([x for x in arr[1:] if x >= pivot])", "domain": "coding"},
-        {"text": "import torch\nimport torch.nn as nn\nclass MoE(nn.Module):\n    def __init__(self):\n        super().__init__()", "domain": "coding"}
+        {"text": "import torch\nimport torch.nn as nn\nclass MoE(nn.Module):\n    def __init__(self):\n        super().__init__()", "domain": "coding"},
     ] * 20  # Repeat to get a decent number of samples
 
-class MockMoEModel:
-    """A mock model that simulates MoE router outputs with artificial correlations for testing."""
-    def __init__(self, num_layers=4, num_experts=16, top_k=2):
-        self.num_layers = num_layers
-        self.num_experts = num_experts
+
+# --------------------------------------------------------------------- mock
+
+
+class MockRouter(nn.Module):
+    """Mimics the Gemma4 router contract: returns (probs, top_k_weights, top_k_index)."""
+
+    def __init__(self, top_k):
+        super().__init__()
         self.top_k = top_k
-        
-        class Config:
-            pass
-        self.config = Config()
-        self.config.num_hidden_layers = num_layers
-        self.config.num_local_experts = num_experts
-        self.config.num_experts_per_tok = top_k
-        self.device = "cpu"
-        
-    def eval(self):
-        pass
-        
-    def __call__(self, input_ids, **kwargs):
-        batch_size, seq_len = input_ids.shape
-        logits = tuple(torch.randn(batch_size, seq_len, self.num_experts) for _ in range(self.num_layers))
-        
-        # Inject artificial bias based on the first token to simulate domain specific experts
-        # and cross-layer correlations
-        domain_hash = (input_ids[0, 0].item() % self.num_experts)
-        for l in range(self.num_layers):
-            # 1. Domain bias: some expert is strongly associated with the domain
-            main_expert = (domain_hash + l * 2) % self.num_experts
-            logits[l][:, :, main_expert] += 8.0
-            
-            # 2. Within-layer correlation: if main_expert is active, paired_expert is also active
-            paired_expert = (main_expert + 1) % self.num_experts
-            logits[l][:, :, paired_expert] += 6.0
-            
-            # 3. Cross-layer correlation: main_expert in layer l strongly predicts next_expert in l+1
-            # (Handled implicitly by the deterministic `main_expert` progression `domain_hash + l*2`)
-            
-        class Output:
-            pass
-        out = Output()
-        out.router_logits = logits
-        return out
+
+    def forward(self, logits):
+        probs = torch.softmax(logits, dim=-1)
+        top_w, top_i = torch.topk(probs, self.top_k, dim=-1)
+        return probs, top_w, top_i
+
+
+class MockMoELayer(nn.Module):
+    def __init__(self, num_experts, top_k, hidden, inter):
+        super().__init__()
+        self.router = MockRouter(top_k)
+        # Only the shapes matter: MoEArch.from_model reads them.
+        self.experts = SimpleNamespace(
+            gate_up_proj=torch.zeros(num_experts, 2 * inter, hidden),
+            down_proj=torch.zeros(num_experts, inter, hidden),
+        )
+
+
+class MockMoEModel(nn.Module):
+    """Fake MoE model with artificial domain / pair / cross-layer correlations.
+
+    Structurally compatible with ``exex.arch`` (``.model.layers[i].router`` and
+    ``.experts``), so ``RoutingAnalyzer`` can hook it like a real model.
+    """
+
+    def __init__(self, num_layers=4, num_experts=16, top_k=2, hidden=8, inter=4):
+        super().__init__()
+        self.config = SimpleNamespace(
+            num_hidden_layers=num_layers,
+            num_experts=num_experts,
+            top_k_experts=top_k,
+            hidden_size=hidden,
+            moe_intermediate_size=inter,
+            enable_moe_block=True,
+        )
+        self.model = SimpleNamespace(
+            layers=nn.ModuleList(
+                MockMoELayer(num_experts, top_k, hidden, inter) for _ in range(num_layers)
+            )
+        )
+        self.num_experts = num_experts
+
+    @property
+    def device(self):
+        return torch.device("cpu")
+
+    def forward(self, input_ids, **kwargs):
+        batch, seq_len = input_ids.shape
+        E = self.num_experts
+        domain_hash = input_ids[0, 0].item() % E
+        for l, layer in enumerate(self.model.layers):
+            logits = torch.randn(batch, seq_len, E)
+            # 1. Domain bias: one expert strongly tied to the domain
+            main_expert = (domain_hash + l * 2) % E
+            logits[:, :, main_expert] += 8.0
+            # 2. Within-layer pair: main_expert co-fires with its neighbour
+            logits[:, :, (main_expert + 1) % E] += 6.0
+            # 3. Cross-layer pipeline emerges from the deterministic l*2 progression
+            layer.router(logits)
+        return None
+
 
 class MockTokenizer:
     def __call__(self, text, return_tensors="pt", **kwargs):
-        # Create dummy input ids based on string hash to give different inputs different domains
+        # Hash the text so that different domains map to different first tokens
         hashed = sum(ord(c) for c in text)
-        return {"input_ids": torch.tensor([[hashed, hashed+1, hashed+2, hashed+3]])}
+        return {"input_ids": torch.tensor([[hashed, hashed + 1, hashed + 2, hashed + 3]])}
 
-def generate_report():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--model_path", type=str, default="mock", help="Path to model or 'mock'")
-    parser.add_argument("--output_dir", type=str, default="./report", help="Directory to save report")
-    args = parser.parse_args()
-    
-    os.makedirs(args.output_dir, exist_ok=True)
-    
-    if args.model_path == "mock":
-        print("Using Mock MoE Model")
-        model = MockMoEModel(num_layers=8, num_experts=32, top_k=4)
-        tokenizer = MockTokenizer()
-    else:
-        from transformers import AutoModelForCausalLM, AutoTokenizer
-        model = AutoModelForCausalLM.from_pretrained(args.model_path, device_map="auto", output_router_logits=True)
-        tokenizer = AutoTokenizer.from_pretrained(args.model_path)
-        
-    dataset = create_nordic_dataset()
-    
-    num_layers = model.config.num_hidden_layers
-    num_experts = getattr(model.config, "num_local_experts", getattr(model.config, "n_routed_experts", 32))
-    top_k = getattr(model.config, "num_experts_per_tok", 2)
-    
-    # Stats to collect
-    domain_expert_counts = defaultdict(lambda: np.zeros((num_layers, num_experts)))
-    domain_token_counts = defaultdict(int)
-    
-    # [layer][expert_i][expert_j]
-    within_layer_co = np.zeros((num_layers, num_experts, num_experts))
-    
-    # [layer][expert_l][expert_l+1]
-    cross_layer_co = np.zeros((num_layers - 1, num_experts, num_experts))
-    
-    # All probabilities for density plot: [domain][layer][expert] = list of probs
-    all_probs = defaultdict(list)
-    
-    print("Running prompt processing on dataset...")
-    for row in tqdm(dataset):
-        domain = row["domain"]
-        text = row["text"]
-        
-        inputs = tokenizer(text, return_tensors="pt")
-        if hasattr(model, "device") and model.device != "cpu":
-            inputs = {k: v.to(model.device) for k, v in inputs.items()}
-            
-        with torch.no_grad():
-            outputs = model(**inputs)
-            
-        router_logits = outputs.router_logits
-        seq_len = inputs["input_ids"].shape[1]
-        domain_token_counts[domain] += seq_len
-        
-        # Parse logits
-        prev_layer_experts = None
-        
-        for l, logits in enumerate(router_logits):
-            probs = torch.softmax(logits, dim=-1)
-            # flattened to (seq_len, num_experts)
-            probs = probs.view(-1, num_experts).cpu().numpy()
-            
-            top_k_indices = np.argsort(probs, axis=-1)[:, -top_k:]
-            
-            for t_idx in range(seq_len):
-                token_experts = top_k_indices[t_idx]
-                
-                # Record activation and probability
-                for e in token_experts:
-                    domain_expert_counts[domain][l, e] += 1
-                    all_probs[domain].append(probs[t_idx, e])
-                    
-                # Within layer co-occurrence
-                for i in range(len(token_experts)):
-                    for j in range(i + 1, len(token_experts)):
-                        e1, e2 = token_experts[i], token_experts[j]
-                        within_layer_co[l, e1, e2] += 1
-                        within_layer_co[l, e2, e1] += 1
-                        
-                # Cross layer transitions
-                if prev_layer_experts is not None:
-                    prev_tokens = prev_layer_experts[t_idx]
-                    for pe in prev_tokens:
-                        for ce in token_experts:
-                            cross_layer_co[l-1, pe, ce] += 1
-                            
-            prev_layer_experts = top_k_indices
-            
-    # Normalize co-occurrences by total tokens to get probabilities
-    total_tokens = sum(domain_token_counts.values())
-    
-    # 1. Bar Plots: Domain vs Expert Activations
+
+# ------------------------------------------------------------------ report
+
+
+def find_pipelines(cross_layer_co, layer_marginals, total_tokens, threshold=0.6, top=5):
+    """Trace chains of experts across layers where P(e_{l+1} | e_l) > threshold."""
+    num_layers, num_experts = layer_marginals.shape
+    paths = []
+    for l in range(num_layers - 1):
+        for e in range(num_experts):
+            if layer_marginals[l, e] < total_tokens * 0.01:  # skip very rare experts
+                continue
+            for next_e in range(num_experts):
+                prob = cross_layer_co[l, e, next_e] / layer_marginals[l, e]
+                if prob > threshold:
+                    paths.append({"start_layer": l, "path": [e, next_e], "prob": prob})
+
+    for p in paths:
+        layer = p["start_layer"] + len(p["path"]) - 1
+        expert = p["path"][-1]
+        while layer < num_layers - 1:
+            row = cross_layer_co[layer, expert] / max(1, layer_marginals[layer, expert])
+            best_next = int(np.argmax(row))
+            if row[best_next] > threshold:
+                p["path"].append(best_next)
+                expert = best_next
+                layer += 1
+            else:
+                break
+
+    paths.sort(key=lambda x: len(x["path"]), reverse=True)
+    return paths[:top]
+
+
+def tag_experts(domain_counts, domain_tokens, threshold=0.1):
+    """Label each expert with the domain that activates it most (per token)."""
+    num_layers, num_experts = next(iter(domain_counts.values())).shape
+    tags = {l: {} for l in range(num_layers)}
+    for l in range(num_layers):
+        for e in range(num_experts):
+            best_domain, best_val = None, 0
+            for domain, counts in domain_counts.items():
+                val = counts[l, e] / max(1, domain_tokens[domain])
+                if val > best_val:
+                    best_val, best_domain = val, domain
+            if best_val > threshold:
+                tags[l][e] = best_domain
+    return tags
+
+
+def make_plots(results, output_dir):
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
+    domain_counts = results["domain_expert_activations"]
+    domain_tokens = results["total_tokens_per_domain"]
+    within = results["co_occurrence"]
+    cross = results["cross_layer_co"]
+    num_layers, num_experts = within.shape[:2]
+    total_tokens = sum(domain_tokens.values())
+
     print("Generating Bar Plots...")
-    plt.figure(figsize=(15, 8))
-    for i, domain in enumerate(domain_expert_counts.keys()):
-        plt.subplot(2, 4, i+1)
-        # Average activation across all layers for this domain
-        avg_act = np.sum(domain_expert_counts[domain], axis=0) / (domain_token_counts[domain] * num_layers)
+    domains = list(domain_counts)
+    cols = 4
+    rows = (len(domains) + cols - 1) // cols
+    plt.figure(figsize=(15, 4 * rows))
+    for i, domain in enumerate(domains):
+        plt.subplot(rows, cols, i + 1)
+        avg_act = domain_counts[domain].sum(axis=0) / (domain_tokens[domain] * num_layers)
         plt.bar(range(num_experts), avg_act)
         plt.title(f"Domain: {domain}")
         plt.xlabel("Expert Index")
         plt.ylabel("Activation Freq")
     plt.tight_layout()
-    bar_plot_path = os.path.join(args.output_dir, "domain_bar_plots.png")
-    plt.savefig(bar_plot_path)
+    plt.savefig(os.path.join(output_dir, "domain_bar_plots.png"))
     plt.close()
-    
-    # 2. Density Plots: Distribution of activation probabilities
+
     print("Generating Density Plots...")
     plt.figure(figsize=(10, 6))
-    for domain in domain_expert_counts.keys():
-        sns.kdeplot(all_probs[domain], label=domain, fill=True, alpha=0.3, clip=(0.0, 1.0))
-    plt.title("Density of Top-K Expert Activation Probabilities by Domain")
-    plt.xlabel("Softmax Probability")
+    for domain in domains:
+        sns.kdeplot(results["top_k_weights"][domain], label=domain, fill=True, alpha=0.3,
+                    clip=(0.0, 1.0))
+    plt.title("Density of Top-K Expert Routing Weights by Domain")
+    plt.xlabel("Router Weight")
     plt.ylabel("Density")
     plt.legend()
-    density_plot_path = os.path.join(args.output_dir, "density_plots.png")
-    plt.savefig(density_plot_path)
+    plt.savefig(os.path.join(output_dir, "density_plots.png"))
     plt.close()
-    
-    # 3. Heatmaps: Expert correlation matrices (just doing first 4 layers to save space)
+
     print("Generating Heatmaps...")
     plt.figure(figsize=(16, 4))
     for l in range(min(4, num_layers)):
-        plt.subplot(1, 4, l+1)
-        sns.heatmap(within_layer_co[l] / max(1, total_tokens), cmap="YlGnBu", cbar=False)
+        plt.subplot(1, 4, l + 1)
+        sns.heatmap(within[l] / max(1, total_tokens), cmap="YlGnBu", cbar=False)
         plt.title(f"Layer {l} Correlations")
         plt.xlabel("Expert")
         plt.ylabel("Expert")
     plt.tight_layout()
-    heatmap_path = os.path.join(args.output_dir, "correlation_heatmaps.png")
-    plt.savefig(heatmap_path)
+    plt.savefig(os.path.join(output_dir, "correlation_heatmaps.png"))
     plt.close()
 
-    # 3.5 Cross-Layer Heatmaps
     print("Generating Cross-Layer Heatmaps...")
     plt.figure(figsize=(16, 4))
     for l in range(min(4, num_layers - 1)):
-        plt.subplot(1, 4, l+1)
-        sns.heatmap(cross_layer_co[l] / max(1, total_tokens), cmap="YlOrRd", cbar=False)
-        plt.title(f"Layer {l} -> {l+1} Correlations")
-        plt.xlabel(f"Expert L+{l+1}")
+        plt.subplot(1, 4, l + 1)
+        sns.heatmap(cross[l] / max(1, total_tokens), cmap="YlOrRd", cbar=False)
+        plt.title(f"Layer {l} -> {l + 1} Correlations")
+        plt.xlabel(f"Expert L+{l + 1}")
         plt.ylabel(f"Expert L+{l}")
     plt.tight_layout()
-    cross_heatmap_path = os.path.join(args.output_dir, "cross_layer_heatmaps.png")
-    plt.savefig(cross_heatmap_path)
+    plt.savefig(os.path.join(output_dir, "cross_layer_heatmaps.png"))
     plt.close()
-    
-    # 4. Longest Experts calculation
-    print("Finding Longest Experts...")
-    # Find paths of highly correlated experts across layers
-    # We trace paths where P(e_{l+1} | e_l) is high
-    longest_paths = []
-    
-    # Calculate P(e_{l+1} | e_l)
-    # marginals for e_l across all tokens
-    layer_marginals = np.zeros((num_layers, num_experts))
-    for domain in domain_expert_counts:
-        layer_marginals += domain_expert_counts[domain]
-        
-    for l in range(num_layers - 1):
-        for e in range(num_experts):
-            if layer_marginals[l, e] < total_tokens * 0.01: # Skip very rare experts
-                continue
-            for next_e in range(num_experts):
-                prob = cross_layer_co[l, e, next_e] / layer_marginals[l, e]
-                if prob > 0.6: # Strong transition
-                    longest_paths.append({
-                        "start_layer": l,
-                        "path": [e, next_e],
-                        "prob": prob
-                    })
-                    
-    # Extend paths
-    for p in longest_paths:
-        current_layer = p["start_layer"] + len(p["path"]) - 1
-        current_expert = p["path"][-1]
-        
-        while current_layer < num_layers - 1:
-            best_next = -1
-            best_prob = 0
-            for next_e in range(num_experts):
-                prob = cross_layer_co[current_layer, current_expert, next_e] / max(1, layer_marginals[current_layer, current_expert])
-                if prob > 0.6 and prob > best_prob:
-                    best_prob = prob
-                    best_next = next_e
-                    
-            if best_next != -1:
-                p["path"].append(best_next)
-                current_expert = best_next
-                current_layer += 1
-            else:
-                break
-                
-    # Filter to longest unique paths
-    longest_paths.sort(key=lambda x: len(x["path"]), reverse=True)
-    top_paths = longest_paths[:5] if longest_paths else []
-    
-    # 5. Tagging experts
-    tags = {}
-    for l in range(num_layers):
-        tags[l] = {}
-        for e in range(num_experts):
-            best_domain = None
-            best_val = 0
-            for domain in domain_expert_counts:
-                # normalize by domain tokens to avoid English dominating
-                val = domain_expert_counts[domain][l, e] / domain_token_counts[domain]
-                if val > best_val:
-                    best_val = val
-                    best_domain = domain
-            if best_val > 0.1: # Threshold to be considered a specialist
-                tags[l][e] = best_domain
-                
-    # 6. Write Markdown Report
-    print("Writing Report...")
-    report_path = os.path.join(args.output_dir, "report.md")
+
+
+def write_report(results, model_path, output_dir, top_paths, tags):
+    domain_tokens = results["total_tokens_per_domain"]
+    total_tokens = sum(domain_tokens.values())
+    num_layers = results["co_occurrence"].shape[0]
+
+    report_path = os.path.join(output_dir, "report.md")
     with open(report_path, "w") as f:
         f.write("# MoE Expert Analysis Report\n\n")
-        f.write(f"**Model:** `{args.model_path}`\n")
-        f.write(f"**Total Tokens Processed:** {total_tokens}\n\n")
-        
+        f.write(f"**Model:** `{model_path}`\n")
+        f.write(f"**Total Tokens Processed:** {total_tokens}\n")
+        f.write(f"**MoE Layers:** {num_layers}\n\n")
+
         f.write("## 1. Takeaways\n")
-        f.write("- **Domain Specialization:** Certain experts show strong specialization for specific languages and domains. We observed distinct routing patterns for Norwegian (Bokmål/Nynorsk) vs. STEM/Coding.\n")
-        f.write("- **Block-wise Correlations:** Experts often fire in pairs. For instance, syntax-heavy experts often co-activate with logic experts in coding domains.\n")
-        f.write("- **Consecutive Expert Paths:** The model exhibits 'expert pipelines' where information is routed through the same sequence of experts across multiple layers.\n\n")
-        
+        f.write("- **Domain Specialization:** Certain experts show strong specialization for specific languages and domains.\n")
+        f.write("- **Block-wise Correlations:** Experts often fire in pairs within a layer.\n")
+        f.write("- **Consecutive Expert Paths:** 'Expert pipelines' route the same token through a predictable sequence of experts across layers.\n\n")
+
         f.write("## 2. Longest Experts (Cross-Layer Pipelines)\n")
-        f.write("These are sequences of experts that are strongly correlated across consecutive layers (i.e. activating Expert A in Layer L strongly predicts Expert B in Layer L+1).\n\n")
-        
+        f.write("Sequences of experts strongly correlated across consecutive MoE layers (activating Expert A in layer L strongly predicts Expert B in layer L+1).\n\n")
         if top_paths:
             for i, p in enumerate(top_paths):
-                path_str = " -> ".join([f"E{e}" for e in p["path"]])
-                f.write(f"- **Pipeline {i+1}** (Length {len(p['path'])}): Starts at Layer {p['start_layer']} | Sequence: `{path_str}`\n")
+                path_str = " -> ".join(f"E{e}" for e in p["path"])
+                f.write(f"- **Pipeline {i + 1}** (Length {len(p['path'])}): Starts at Layer {p['start_layer']} | Sequence: `{path_str}`\n")
         else:
             f.write("- No strong multi-layer pipelines detected with threshold P > 0.6.\n")
         f.write("\n")
-        
+
         f.write("## 3. Visualizations\n\n")
-        
         f.write("### Domain Activations (Bar Plots)\n")
-        f.write("Shows which experts are most frequently activated for each domain across all layers.\n\n")
+        f.write("Which experts are most frequently activated for each domain across all layers.\n\n")
         f.write("![Domain Bar Plots](./domain_bar_plots.png)\n\n")
-        
-        f.write("### Activation Probabilities (Density Plots)\n")
-        f.write("Distribution of the routing softmax probabilities for selected experts. A bimodal distribution indicates strong certainty in routing.\n\n")
+        f.write("### Routing Weights (Density Plots)\n")
+        f.write("Distribution of the router weights of selected experts. A bimodal distribution indicates strong certainty in routing.\n\n")
         f.write("![Density Plots](./density_plots.png)\n\n")
-        
         f.write("### Layer Correlations (Heatmaps)\n")
-        f.write("Co-occurrence matrices for the first 4 layers. Bright spots off the diagonal indicate experts that consistently activate together.\n\n")
+        f.write("Co-occurrence matrices for the first 4 MoE layers. Bright spots off the diagonal indicate experts that consistently activate together.\n\n")
         f.write("![Correlation Heatmaps](./correlation_heatmaps.png)\n\n")
-        
         f.write("### Cross-Layer Correlations\n")
-        f.write("Transition probabilities from Layer L to Layer L+1. Bright spots indicate strong predictive flow between experts.\n\n")
+        f.write("Transition counts from layer L to layer L+1. Bright spots indicate strong predictive flow between experts.\n\n")
         f.write("![Cross-Layer Heatmaps](./cross_layer_heatmaps.png)\n\n")
-        
+
         f.write("## 4. Expert Tags (Top Specialists)\n")
-        f.write("Based on relative activation frequencies, we have tagged the following experts:\n\n")
-        for l in range(min(2, num_layers)): # Just show first 2 layers for brevity
+        f.write("Based on relative per-token activation frequencies:\n\n")
+        for l in range(min(2, num_layers)):
             f.write(f"### Layer {l}\n")
             if not tags[l]:
                 f.write("- No distinct specialists found.\n")
@@ -342,8 +287,48 @@ def generate_report():
                 for e, domain in tags[l].items():
                     f.write(f"- **Expert {e}**: Tagged as `{domain}` specialist.\n")
             f.write("\n")
+    return report_path
 
+
+def generate_report():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_path", type=str, default="mock", help="Path to model or 'mock'")
+    parser.add_argument("--output_dir", type=str, default="./report", help="Directory to save report")
+    parser.add_argument("--max_samples", type=int, default=100, help="Max samples per domain")
+    parser.add_argument("--device", type=str, default=None, help="Device override")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    if args.model_path == "mock":
+        print("Using Mock MoE Model")
+        analyzer = RoutingAnalyzer(
+            MockMoEModel(num_layers=8, num_experts=32, top_k=4), tokenizer=MockTokenizer()
+        )
+    else:
+        analyzer = RoutingAnalyzer(args.model_path, device=args.device)
+
+    print("Running prompt processing on dataset...")
+    results = analyzer.analyze_dataset(
+        create_nordic_dataset(), max_samples_per_domain=args.max_samples
+    )
+
+    domain_counts = results["domain_expert_activations"]
+    domain_tokens = results["total_tokens_per_domain"]
+    total_tokens = sum(domain_tokens.values())
+
+    make_plots(results, args.output_dir)
+
+    print("Finding Longest Experts...")
+    layer_marginals = sum(domain_counts.values())
+    top_paths = find_pipelines(results["cross_layer_co"], layer_marginals, total_tokens)
+
+    tags = tag_experts(domain_counts, domain_tokens)
+
+    print("Writing Report...")
+    report_path = write_report(results, args.model_path, args.output_dir, top_paths, tags)
     print(f"Report generated successfully at {report_path}")
+
 
 if __name__ == "__main__":
     generate_report()

--- a/scripts/run_analysis.py
+++ b/scripts/run_analysis.py
@@ -6,6 +6,7 @@ import os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
 from exex.analyzer import RoutingAnalyzer
 
+
 def create_dummy_dataset():
     """
     Creates a small mock dataset for testing purposes if a real dataset isn't provided.
@@ -22,15 +23,18 @@ def create_dummy_dataset():
         {"text": "El tiempo vuela como una flecha. La mosca de la fruta vuela como un plátano.", "domain": "multilingual"},
     ] * 10  # Multiply to have more samples
 
+
 def main():
     parser = argparse.ArgumentParser(description="Analyze MoE routing behavior across domains.")
     parser.add_argument("--model_path", type=str, required=True, help="Path to the MoE model (local or HF hub)")
     parser.add_argument("--dataset_path", type=str, default=None, help="Path to HF dataset. Uses dummy data if not provided.")
     parser.add_argument("--max_samples", type=int, default=50, help="Max samples per domain to analyze")
+    parser.add_argument("--device", type=str, default=None, help="Device override (default: cuda if available)")
+    parser.add_argument("--max_length", type=int, default=512, help="Truncation length per sample")
 
     args = parser.parse_args()
 
-    analyzer = RoutingAnalyzer(args.model_path)
+    analyzer = RoutingAnalyzer(args.model_path, device=args.device, max_length=args.max_length)
 
     if args.dataset_path:
         from datasets import load_dataset
@@ -49,6 +53,7 @@ def main():
 
     analyzer.print_associations(results)
     analyzer.find_correlations(results, threshold_ratio=0.75)
+
 
 if __name__ == "__main__":
     main()

--- a/src/exex/analyzer.py
+++ b/src/exex/analyzer.py
@@ -1,155 +1,223 @@
-import torch
-import numpy as np
+"""
+Router behaviour analysis via forward hooks on each MoE layer's ``router``.
+
+Works on transformers 5, which no longer accepts ``output_router_logits`` for
+Gemma 4. Instead we register a forward hook on every ``layer.router`` (the same
+pattern as :func:`exex.pruner.collect_router_stats`) and read the routing
+decision the model actually made -- ``(router_probabilities, top_k_weights,
+top_k_index)`` -- so per-expert scaling and any other router-internal logic are
+respected rather than re-derived from a plain softmax.
+"""
+
 from collections import defaultdict
 import itertools
-from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import numpy as np
+import torch
 from tqdm import tqdm
 
-class RoutingAnalyzer:
-    def __init__(self, model_path, device=None):
-        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
-        device = self.device
-        self.tokenizer = AutoTokenizer.from_pretrained(model_path)
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_path,
-            device_map=device,
-            output_router_logits=True,
-            torch_dtype=torch.float16 if device == "cuda" else torch.float32
-        )
-        self.config = self.model.config
+from exex.arch import MoEArch, iter_moe_layers
 
-        # Architecture parameters derived from the model itself
-        from exex.arch import MoEArch
+
+def _load_dtype(device):
+    """bf16 on CUDA (matches the checkpoints), fp32 elsewhere. Never fp16."""
+    return torch.bfloat16 if str(device).startswith("cuda") else torch.float32
+
+
+class RoutingAnalyzer:
+    """Collect per-domain expert activation and co-occurrence statistics.
+
+    Args:
+        model_path_or_model: HF hub id / local path, or an already-loaded model
+            exposing per-layer ``router`` / ``experts`` modules.
+        device: target device; defaults to cuda if available. Ignored when an
+            already-loaded model is passed (its own device is used).
+        tokenizer: optional tokenizer-like callable
+            ``tok(text, return_tensors="pt", truncation=..., max_length=...)``
+            returning a mapping with ``input_ids``. Loaded from the model path
+            when omitted; required when passing a model object.
+        max_length: truncation length for each sample.
+    """
+
+    def __init__(self, model_path_or_model, device=None, tokenizer=None, max_length=512):
+        self.max_length = max_length
+        if isinstance(model_path_or_model, str):
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+
+            self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+            self.model = AutoModelForCausalLM.from_pretrained(
+                model_path_or_model,
+                device_map=self.device,
+                dtype=_load_dtype(self.device),
+            )
+            self.tokenizer = tokenizer or AutoTokenizer.from_pretrained(model_path_or_model)
+        else:
+            self.model = model_path_or_model
+            self.device = getattr(self.model, "device", None) or device or "cpu"
+            if tokenizer is None:
+                raise ValueError("tokenizer is required when passing an already-loaded model")
+            self.tokenizer = tokenizer
+
+        self.config = self.model.config
         self.arch = MoEArch.from_model(self.model)
+        self.moe_layers = list(iter_moe_layers(self.model))
+        # Result matrices are indexed by MoE-layer *position*, not decoder index.
+        self.num_moe_layers = len(self.moe_layers)
         self.num_layers = self.arch.num_layers
         self.num_experts = self.arch.num_experts
         self.top_k = self.arch.top_k
+        self._captured = {}
+
+    # ------------------------------------------------------------------ hooks
+
+    def _make_hook(self, pos):
+        def hook(module, args, output, _pos=pos):
+            _, top_k_weights, top_k_index = output
+            k = top_k_index.shape[-1]
+            self._captured[_pos] = (
+                top_k_index.reshape(-1, k).detach().cpu(),
+                top_k_weights.reshape(-1, k).detach().float().cpu(),
+            )
+
+        return hook
+
+    def _register_hooks(self):
+        return [
+            layer.router.register_forward_hook(self._make_hook(pos))
+            for pos, (_, layer) in enumerate(self.moe_layers)
+        ]
+
+    # --------------------------------------------------------------- analysis
 
     @torch.no_grad()
-    def analyze_dataset(self, dataset, text_col="text", domain_col="domain", max_samples_per_domain=100):
+    def analyze_dataset(self, dataset, text_col="text", domain_col="domain",
+                        max_samples_per_domain=100, verbose=True):
+        """Analyze router behaviour over a multi-domain dataset.
+
+        Returns a dict with:
+            domain_expert_activations: {domain: [num_moe_layers, E]} selection counts
+            co_occurrence: [num_moe_layers, E, E] symmetric within-token pair counts
+                (zero diagonal)
+            cross_layer_co: [num_moe_layers - 1, E, E] counts of
+                (expert at layer l, expert at l+1) for the same token
+            top_k_weights: {domain: 1-D array} router weight of every selection
+            total_tokens_per_domain: {domain: int}
         """
-        Analyzes router behavior over a multi-domain dataset.
-        Returns matrices for expert-domain association and expert co-occurrence.
-        """
-        defaultdict(int)
+        L, E, k = self.num_moe_layers, self.num_experts, self.top_k
+        activations = defaultdict(lambda: torch.zeros(L, E, dtype=torch.float64))
+        co_occurrence = torch.zeros(L, E, E, dtype=torch.float64)
+        cross_layer_co = torch.zeros(max(L - 1, 0), E, E, dtype=torch.float64)
+        top_k_weights = defaultdict(list)
+        total_tokens = defaultdict(int)
+        pair_offsets = list(itertools.combinations(range(k), 2))
 
-        # We track how many times each expert was selected per layer per domain
-        # shape: (num_layers, num_experts)
-        domain_expert_activations = defaultdict(lambda: np.zeros((self.num_layers, self.num_experts)))
-
-        # We track co-occurrence of experts within the same token routing decision
-        # shape: (num_layers, num_experts, num_experts)
-        co_occurrence = np.zeros((self.num_layers, self.num_experts, self.num_experts))
-        total_tokens_per_domain = defaultdict(int)
-
-        self.model.eval()
-
-        # Organize dataset by domain to easily enforce max_samples_per_domain
         domain_data = defaultdict(list)
         for row in dataset:
             domain = row[domain_col]
             if len(domain_data[domain]) < max_samples_per_domain:
                 domain_data[domain].append(row[text_col])
 
-        for domain, texts in domain_data.items():
-            print(f"Analyzing domain: {domain}")
-            for text in tqdm(texts, desc=f"Processing {domain}"):
-                inputs = self.tokenizer(text, return_tensors="pt", truncation=True, max_length=512).to(self.device)
+        self.model.eval()
+        handles = self._register_hooks()
+        try:
+            for domain, texts in domain_data.items():
+                iterator = tqdm(texts, desc=f"Processing {domain}") if verbose else texts
+                for text in iterator:
+                    inputs = self.tokenizer(
+                        text, return_tensors="pt", truncation=True, max_length=self.max_length
+                    )
+                    input_ids = inputs["input_ids"].to(self.device)
+                    self._captured = {}
+                    self.model(input_ids=input_ids)
+                    total_tokens[domain] += input_ids.numel()
 
-                # Forward pass
-                outputs = self.model(**inputs)
+                    prev_idx = None
+                    for pos in range(L):
+                        idx, w = self._captured[pos]  # [T, k] each
+                        activations[domain][pos] += torch.bincount(
+                            idx.reshape(-1), minlength=E
+                        ).double()
+                        top_k_weights[domain].append(w.reshape(-1))
+                        for i, j in pair_offsets:
+                            pairs = idx[:, i] * E + idx[:, j]
+                            co_occurrence[pos] += torch.bincount(
+                                pairs, minlength=E * E
+                            ).double().view(E, E)
+                        if prev_idx is not None:
+                            # every (prev expert, current expert) pair per token
+                            pairs = (prev_idx.unsqueeze(2) * E + idx.unsqueeze(1)).reshape(-1)
+                            cross_layer_co[pos - 1] += torch.bincount(
+                                pairs, minlength=E * E
+                            ).double().view(E, E)
+                        prev_idx = idx
+        finally:
+            for h in handles:
+                h.remove()
+            self._captured = {}
 
-                # router_logits is a tuple of (batch_size, sequence_length, num_experts)
-                router_logits = outputs.router_logits
+        # Pair counts were accumulated one-directionally; make symmetric.
+        co_occurrence = co_occurrence + co_occurrence.transpose(1, 2)
 
-                seq_len = inputs.input_ids.shape[1]
-                total_tokens_per_domain[domain] += seq_len
-
-                for layer_idx, logits in enumerate(router_logits):
-                    # probabilities -> (1, seq_len, num_experts)
-                    probs = torch.softmax(logits, dim=-1)
-
-                    # Top-k indices -> (1, seq_len, top_k)
-                    top_k_indices = torch.topk(probs, self.top_k, dim=-1).indices
-
-                    # Flatten batch and seq length -> (seq_len, top_k)
-                    top_k_indices = top_k_indices.view(-1, self.top_k).cpu().numpy()
-
-                    for token_experts in top_k_indices:
-                        for exp_idx in token_experts:
-                            domain_expert_activations[domain][layer_idx, exp_idx] += 1
-
-                        # Update co-occurrence matrix for pairs (combinations of 2)
-                        for exp_i, exp_j in itertools.combinations(token_experts, 2):
-                            co_occurrence[layer_idx, exp_i, exp_j] += 1
-                            co_occurrence[layer_idx, exp_j, exp_i] += 1
-
-        results = {
-            "domain_expert_activations": dict(domain_expert_activations),
-            "co_occurrence": co_occurrence,
-            "total_tokens_per_domain": dict(total_tokens_per_domain)
+        return {
+            "domain_expert_activations": {d: a.numpy() for d, a in activations.items()},
+            "co_occurrence": co_occurrence.numpy(),
+            "cross_layer_co": cross_layer_co.numpy(),
+            "top_k_weights": {
+                d: torch.cat(ws).numpy() if ws else np.zeros(0)
+                for d, ws in top_k_weights.items()
+            },
+            "total_tokens_per_domain": dict(total_tokens),
         }
-        return results
 
-    def print_associations(self, results):
-        """Identifies which experts are most associated with which domains."""
+    # ---------------------------------------------------------------- reports
+
+    def print_associations(self, results, top_n=3):
+        """Print the experts most associated with each domain, per MoE layer."""
         activations = results["domain_expert_activations"]
         tokens = results["total_tokens_per_domain"]
 
         print("\n--- Expert-Domain Associations ---")
-        for domain in activations:
-            # Average activations per token for this domain
-            avg_act = activations[domain] / tokens[domain]
-
+        for domain, counts in activations.items():
+            avg_act = counts / max(tokens[domain], 1)
             print(f"\nDomain: {domain} (Tokens: {tokens[domain]})")
-            for layer in range(self.num_layers):
-                # Find top 3 experts for this layer and domain
-                top_experts = np.argsort(avg_act[layer])[::-1][:3]
-                print(f"  Layer {layer:02d} Top Experts: " +
-                      ", ".join([f"E{e} ({avg_act[layer, e]:.3f}/tok)" for e in top_experts]))
+            for layer in range(counts.shape[0]):
+                top_experts = np.argsort(avg_act[layer])[::-1][:top_n]
+                print(
+                    f"  MoE layer {layer:02d} Top Experts: "
+                    + ", ".join(f"E{e} ({avg_act[layer, e]:.3f}/tok)" for e in top_experts)
+                )
 
     def find_correlations(self, results, threshold_ratio=0.8):
-        """
-        Identifies block-wise expert correlations.
-        Looks for one-to-one, one-to-many, etc.
-        """
+        """Print block-wise expert correlations; returns [(layer, i, j, kind)]."""
         print("\n--- Block-wise Expert Correlations ---")
         co_occurrence = results["co_occurrence"]
+        total_activations = sum(results["domain_expert_activations"].values())
+        found = []
 
-        # We need the marginal activations to calculate P(A|B) and P(B|A)
-        # We can approximate marginals from the diagonal of co-occurrence if we tracked it,
-        # or we can reconstruct it from domain_expert_activations.
-        total_activations = np.zeros((self.num_layers, self.num_experts))
-        for counts in results["domain_expert_activations"].values():
-            total_activations += counts
-
-        for layer in range(self.num_layers):
+        for layer in range(co_occurrence.shape[0]):
             layer_co = co_occurrence[layer]
             layer_act = total_activations[layer]
+            lines = []
 
-            correlations_found = False
             for i in range(self.num_experts):
                 for j in range(i + 1, self.num_experts):
                     if layer_co[i, j] == 0:
                         continue
-
-                    # Probability of seeing j given i is selected
                     p_j_given_i = layer_co[i, j] / layer_act[i] if layer_act[i] > 0 else 0
-                    # Probability of seeing i given j is selected
                     p_i_given_j = layer_co[i, j] / layer_act[j] if layer_act[j] > 0 else 0
 
                     if p_j_given_i >= threshold_ratio and p_i_given_j >= threshold_ratio:
-                        if not correlations_found:
-                            print(f"\nLayer {layer:02d}:")
-                            correlations_found = True
-                        print(f"  [1-to-1] E{i} <-> E{j} (P(j|i)={p_j_given_i:.2f}, P(i|j)={p_i_given_j:.2f})")
+                        lines.append(f"  [1-to-1] E{i} <-> E{j} "
+                                     f"(P(j|i)={p_j_given_i:.2f}, P(i|j)={p_i_given_j:.2f})")
+                        found.append((layer, i, j, "1-to-1"))
                     elif p_j_given_i >= threshold_ratio:
-                        if not correlations_found:
-                            print(f"\nLayer {layer:02d}:")
-                            correlations_found = True
-                        print(f"  [Many-to-1 / Dependency] E{i} -> E{j} (P(j|i)={p_j_given_i:.2f})")
+                        lines.append(f"  [Dependency] E{i} -> E{j} (P(j|i)={p_j_given_i:.2f})")
+                        found.append((layer, i, j, "dependency"))
                     elif p_i_given_j >= threshold_ratio:
-                        if not correlations_found:
-                            print(f"\nLayer {layer:02d}:")
-                            correlations_found = True
-                        print(f"  [Many-to-1 / Dependency] E{j} -> E{i} (P(i|j)={p_i_given_j:.2f})")
+                        lines.append(f"  [Dependency] E{j} -> E{i} (P(i|j)={p_i_given_j:.2f})")
+                        found.append((layer, j, i, "dependency"))
+
+            if lines:
+                print(f"\nMoE layer {layer:02d}:")
+                print("\n".join(lines))
+        return found

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,98 @@
+import numpy as np
+import pytest
+import torch
+
+from exex.analyzer import RoutingAnalyzer
+
+
+class StubTokenizer:
+    """Deterministic fake tokenizer: text length -> token count (clamped)."""
+
+    def __init__(self, vocab_size=256):
+        self.vocab_size = vocab_size
+
+    def __call__(self, text, return_tensors="pt", truncation=True, max_length=512):
+        n = min(max(len(text.split()), 1), max_length)
+        return {"input_ids": torch.randint(0, self.vocab_size, (1, n))}
+
+
+DATASET = [
+    {"text": "one two three four", "domain": "a"},
+    {"text": "five six", "domain": "a"},
+    {"text": "seven eight nine", "domain": "b"},
+    {"text": "ten", "domain": "b"},
+    {"text": "this sample exceeds max_samples and is skipped", "domain": "b"},
+]
+
+
+@pytest.fixture
+def analyzer(tiny_gemma4_moe):
+    return RoutingAnalyzer(tiny_gemma4_moe, tokenizer=StubTokenizer())
+
+
+@pytest.fixture
+def results(analyzer):
+    return analyzer.analyze_dataset(DATASET, max_samples_per_domain=2, verbose=False)
+
+
+def test_requires_tokenizer_for_model_object(tiny_gemma4_moe):
+    with pytest.raises(ValueError):
+        RoutingAnalyzer(tiny_gemma4_moe)
+
+
+def test_arch_derived(analyzer):
+    assert analyzer.num_moe_layers == 2
+    assert analyzer.num_experts == 4
+    assert analyzer.top_k == 2
+    assert analyzer.device == torch.device("cpu")
+
+
+def test_total_tokens_per_domain(results):
+    assert results["total_tokens_per_domain"] == {"a": 6, "b": 4}
+
+
+def test_activation_shapes_and_topk_conservation(results):
+    acts = results["domain_expert_activations"]
+    assert set(acts) == {"a", "b"}
+    for domain, tokens in results["total_tokens_per_domain"].items():
+        assert acts[domain].shape == (2, 4)
+        # each token selects exactly top_k=2 experts per layer
+        np.testing.assert_array_equal(acts[domain].sum(axis=1), [2 * tokens, 2 * tokens])
+
+
+def test_co_occurrence_symmetric_zero_diagonal(results):
+    co = results["co_occurrence"]
+    assert co.shape == (2, 4, 4)
+    np.testing.assert_array_equal(co, co.transpose(0, 2, 1))
+    for layer in range(2):
+        assert np.all(np.diag(co[layer]) == 0)
+        # one unordered pair per token per layer, counted in both directions
+        assert co[layer].sum() == 2 * 10
+
+
+def test_cross_layer_co(results):
+    cross = results["cross_layer_co"]
+    assert cross.shape == (1, 4, 4)
+    # k * k (prev, cur) pairs per token
+    assert cross.sum() == 4 * 10
+
+
+def test_top_k_weights(results):
+    for domain, tokens in results["total_tokens_per_domain"].items():
+        w = results["top_k_weights"][domain]
+        assert w.shape == (2 * 2 * tokens,)
+        assert np.all(w >= 0) and np.all(w <= 1)
+
+
+def test_hooks_removed_after_analysis(analyzer, results):
+    for _, layer in analyzer.moe_layers:
+        assert not layer.router._forward_hooks
+
+
+def test_report_helpers_run(analyzer, results, capsys):
+    analyzer.print_associations(results)
+    found = analyzer.find_correlations(results, threshold_ratio=0.0)
+    out = capsys.readouterr().out
+    assert "Expert-Domain Associations" in out
+    assert "Block-wise Expert Correlations" in out
+    assert isinstance(found, list)


### PR DESCRIPTION
Closes #27

## Problem
`RoutingAnalyzer.__init__` and `scripts/generate_report.py` passed `output_router_logits=True` to `from_pretrained`, which `Gemma4ForCausalLM` rejects on transformers 5 (`TypeError`). `run_analysis.py` died on any real model and `generate_report.py` only worked with `--model_path mock`. Neither had tests.

## Changes
- **`src/exex/analyzer.py`**: `RoutingAnalyzer` now registers forward hooks on every `layer.router` (same pattern as `pruner.collect_router_stats`) and reads the router's actual `(probs, top_k_weights, top_k_index)` rather than re-deriving top-k from a plain softmax (so `per_expert_scale` etc. are respected). Accepts a model path **or** an already-loaded model plus an optional `tokenizer`. Loads bf16 on cuda / fp32 on cpu (never fp16). Result matrices are indexed by MoE-layer position via `iter_moe_layers`, not `arch.num_layers`. Per-token Python loops replaced with `torch.bincount` over flattened expert / pair indices. Public surface kept (`analyze_dataset` -> `domain_expert_activations`, `co_occurrence`, `total_tokens_per_domain`; `print_associations`; `find_correlations`), with two additive keys: `cross_layer_co` `[L-1, E, E]` and per-domain `top_k_weights`.
- **`scripts/run_analysis.py`**: no more `output_router_logits`; adds `--device` / `--max_length`.
- **`scripts/generate_report.py`**: both the real-model path and `--model_path mock` now go through `RoutingAnalyzer`; the mock is a hook-compatible fake MoE (`.model.layers[i].router` / `.experts`) so the report code is exercised identically. matplotlib / seaborn are imported lazily inside `make_plots`, so importing the module does not require the `analysis` extra.
- **`tests/test_analyzer.py`** (new, 9 tests on `tiny_gemma4_moe`): activation shape `[2,4]`, each token contributes exactly `top_k=2` selections per layer, co-occurrence symmetric with zero diagonal, cross-layer counts, `total_tokens_per_domain`, hooks removed after analysis, report helpers run.
- **README**: analyzer no longer flagged as broken.

## Verification
- `PYTHONPATH=src .venv/bin/python -m pytest -q tests` -> **75 passed** (66 existing + 9 new)
- `uvx ruff check` clean on all touched files (3 pre-existing findings remain in `merge_experts.py`, `train_expert.py`, `trainer.py`, untouched)
- `scripts/generate_report.py --model_path mock` produces `report.md` + 4 PNGs and detects the injected 8-layer pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
