### PR TITLE
feat: clone_expert(router_noise=) to break the tie between a cloned slot and its source

### DIFF
--- a/scripts/train_expert.py
+++ b/scripts/train_expert.py
@@ -38,6 +38,9 @@ def parse_args():
     target.add_argument("--clone_from", type=int, default=None,
                         help="Grow a new slot cloned from this expert and train "
                              "that instead (expert extension)")
+    p.add_argument("--clone_router_noise", type=float, default=0.0,
+                   help="With --clone_from: relative Gaussian noise on the new slot's "
+                        "router row so it does not tie with its source (0 = verbatim copy)")
     p.add_argument("--label", default=None,
                    help="Label recorded in the cartridge manifest / config")
     # optimisation
@@ -97,7 +100,8 @@ def main():
 
     manager = ExpertManager.from_model(model)
     if args.clone_from is not None:
-        new_idx = manager.clone_expert(source_idx=args.clone_from, label=args.label)
+        new_idx = manager.clone_expert(source_idx=args.clone_from, label=args.label,
+                                       router_noise=args.clone_router_noise, seed=args.seed)
         expert_indices = [new_idx]
         print(f"Cloned expert {args.clone_from} -> new slot {new_idx} "
               f"(num_experts now {manager.arch.num_experts})", flush=True)

--- a/src/exex/manager.py
+++ b/src/exex/manager.py
@@ -32,8 +32,19 @@ class ExpertManager:
     def get_labels(self):
         return getattr(self.config, "expert_labels", {})
 
-    def clone_expert(self, source_idx, label=None):
-        """Clone an existing expert to a new slot at the end."""
+    def clone_expert(self, source_idx, label=None, router_noise=0.0, seed=0):
+        """Clone an existing expert to a new slot at the end.
+
+        Args:
+            router_noise: relative std of Gaussian noise added to the new
+                slot's router row (fraction of the row norm / sqrt(hidden)).
+                0 copies the row verbatim, which ties the clone with its
+                source and merely splits traffic (26B clone arm, 2026-09-07);
+                ~0.01-0.05 breaks the tie so the router can specialize the
+                new slot while the expert weights stay identical to the source.
+            seed: RNG seed for the perturbation (deterministic).
+        """
+        gen = torch.Generator().manual_seed(seed)
         if not 0 <= source_idx < self.arch.num_experts:
             raise IndexError(
                 f"source_idx {source_idx} out of range (num_experts={self.arch.num_experts})"
@@ -59,6 +70,11 @@ class ExpertManager:
             experts.num_experts += 1
 
             new_weight = grown(router.proj.weight)
+            if router_noise > 0:
+                row = new_weight.data[-1]
+                scale = router_noise * row.float().norm() / (row.numel() ** 0.5)
+                noise = torch.randn(row.shape, generator=gen, dtype=torch.float32)
+                row.add_((noise * scale).to(device=row.device, dtype=row.dtype))
             router.proj = nn.Linear(new_weight.shape[1], new_weight.shape[0], bias=False,
                                     device="meta")
             router.proj.weight = new_weight

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -48,3 +48,33 @@ class TestExpertManagerGemma4:
         for layer in model.model.layers:
             if hasattr(layer, "experts"):
                 assert layer.experts.gate_up_proj.shape[0] == original_num_experts - 1
+
+
+class TestCloneRouterNoise:
+    def test_verbatim_clone_ties_with_source(self, tiny_gemma4_moe):
+        from exex.manager import ExpertManager
+        m = ExpertManager.from_model(tiny_gemma4_moe)
+        new = m.clone_expert(1)
+        for layer in tiny_gemma4_moe.model.layers:
+            w = layer.router.proj.weight.data
+            assert torch.equal(w[new], w[1])
+
+    def test_noise_breaks_tie_but_keeps_expert_weights(self, tiny_gemma4_moe):
+        from exex.manager import ExpertManager
+        m = ExpertManager.from_model(tiny_gemma4_moe)
+        new = m.clone_expert(1, router_noise=0.02, seed=3)
+        for layer in tiny_gemma4_moe.model.layers:
+            w = layer.router.proj.weight.data
+            rel = (w[new] - w[1]).norm() / w[1].norm()
+            assert 0.005 < rel.item() < 0.05
+            assert torch.equal(layer.experts.gate_up_proj.data[new], layer.experts.gate_up_proj.data[1])
+            assert torch.equal(layer.experts.down_proj.data[new], layer.experts.down_proj.data[1])
+
+    def test_noise_is_deterministic(self, tiny_gemma4_moe):
+        import copy
+        from exex.manager import ExpertManager
+        a = copy.deepcopy(tiny_gemma4_moe); b = copy.deepcopy(tiny_gemma4_moe)
+        ExpertManager.from_model(a).clone_expert(1, router_noise=0.02, seed=7)
+        ExpertManager.from_model(b).clone_expert(1, router_noise=0.02, seed=7)
+        for la, lb in zip(a.model.layers, b.model.layers, strict=True):
+            assert torch.equal(la.router.proj.weight.data, lb.router.proj.weight.data)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -73,7 +73,8 @@ class TestCloneRouterNoise:
     def test_noise_is_deterministic(self, tiny_gemma4_moe):
         import copy
         from exex.manager import ExpertManager
-        a = copy.deepcopy(tiny_gemma4_moe); b = copy.deepcopy(tiny_gemma4_moe)
+        a = copy.deepcopy(tiny_gemma4_moe)
+        b = copy.deepcopy(tiny_gemma4_moe)
         ExpertManager.from_model(a).clone_expert(1, router_noise=0.02, seed=7)
         ExpertManager.from_model(b).clone_expert(1, router_noise=0.02, seed=7)
         for la, lb in zip(a.model.layers, b.model.layers, strict=True):


### PR DESCRIPTION
Clone divergence strategy per ruler (2026-09-07): perturb the cloned router row rather than clone from a different source, so the twin comparison stays clean. `clone_expert(source, router_noise=0.02, seed=0)`, CLI `--clone_router_noise`. Three tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)