### PR TITLE
fix: exclude pad tokens from the router KL, fail fast on non-finite loss, attention mask opt-in

### DIFF
--- a/src/exex/cli/train.py
+++ b/src/exex/cli/train.py
@@ -58,6 +58,14 @@ def build_parser():
     p.add_argument("--lr_decay", default="none", choices=["none", "linear", "cosine"])
     p.add_argument("--weight_decay", type=float, default=0.0)
     p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--attention_mask", default="off", choices=["on", "off"],
+                   help="Pass the padding attention mask to the model. Off by default: "
+                        "with right padding the causal mask already keeps real tokens "
+                        "correct, and Gemma 4 bf16 forwards with a mask produced "
+                        "non-finite pad-row activations that poisoned expert grads "
+                        "(26B, 2026-09-07). Pad labels are always -100 either way.")
+    p.add_argument("--allow_nonfinite", action="store_true",
+                   help="Skip non-finite steps instead of aborting the run")
     p.add_argument("--no_shuffle", action="store_true",
                    help="Iterate the dataset in file order instead of a seeded shuffle")
     # periodic eval
@@ -124,6 +132,7 @@ def main(argv=None):
         total_steps=args.max_steps,
         lr_decay=args.lr_decay,
         weight_decay=args.weight_decay,
+        abort_on_nonfinite=not args.allow_nonfinite,
     )
     n_trainable = sum(p.numel() for p in trainer.trainable_parameters)
 
@@ -172,8 +181,10 @@ def main(argv=None):
                             max_length=args.max_length, padding=True).to(model.device)
             labels = enc.input_ids.clone()
             labels[enc.attention_mask == 0] = -100
-            m = trainer.train_step(input_ids=enc.input_ids,
-                                   attention_mask=enc.attention_mask, labels=labels)
+            step_kwargs = {"input_ids": enc.input_ids, "labels": labels}
+            if args.attention_mask == "on":
+                step_kwargs["attention_mask"] = enc.attention_mask
+            m = trainer.train_step(**step_kwargs)
             tokens_seen += int(enc.attention_mask.sum())
             if not m["stepped"]:
                 continue
@@ -217,6 +228,7 @@ def main(argv=None):
     run = {"args": vars(args), "expert_indices": expert_indices,
            "num_experts": manager.arch.num_experts, "trainable_params": n_trainable,
            "optimizer_steps": step, "tokens_seen": tokens_seen,
+           "nonfinite_steps": trainer.nonfinite_steps,
            "elapsed_s": round(time.time() - t0, 1), "eval_ppl_history": eval_history,
            "artefacts": artefacts}
     with open(os.path.join(args.output_dir, "run.json"), "w") as f:

--- a/src/exex/trainer.py
+++ b/src/exex/trainer.py
@@ -39,6 +39,8 @@ class ExpertTrainer:
         total_steps: optimizer steps for the decay schedule (None = constant)
         lr_decay: "none" | "linear" | "cosine" after warmup
         weight_decay: AdamW weight decay (0 keeps frozen-row semantics exact)
+        abort_on_nonfinite: raise FloatingPointError on a non-finite loss
+            (default) instead of silently training on NaN; False skips the step
     """
 
     def __init__(
@@ -56,6 +58,7 @@ class ExpertTrainer:
         total_steps=None,
         lr_decay="none",
         weight_decay=0.0,
+        abort_on_nonfinite=True,
     ):
         self.backend = get_backend(backend) if isinstance(backend, str) else backend
         self.model = model
@@ -66,6 +69,8 @@ class ExpertTrainer:
         )
         self.kl_weight = kl_weight
         self.train_full_router = train_full_router
+        self.abort_on_nonfinite = abort_on_nonfinite
+        self.nonfinite_steps = 0
 
         # Step 1: Snapshot pretrained router for KL reference (before any freezing)
         self._ref_router_params = self._snapshot_routers()
@@ -176,15 +181,22 @@ class ExpertTrainer:
             handle = layer.router.register_forward_hook(hook_fn)
             self._hooks.append(handle)
 
-    def _compute_kl_loss(self):
+    def _compute_kl_loss(self, token_mask=None):
         """
         Compute KL divergence between current and pretrained router distributions.
 
         Uses captured router inputs (from forward hooks) and frozen parameter
         snapshot to compute reference logits, then KL(current || ref).
+
+        Args:
+            token_mask: optional bool tensor [B*S]; only True positions count.
+                Pad positions must be excluded — with an attention mask their
+                hidden states can be non-finite and would poison the loss.
         """
         device = next(self.model.parameters()).device
         total_kl = torch.tensor(0.0, device=device)
+        if token_mask is not None:
+            token_mask = token_mask.reshape(-1).to(device)
 
         router_idx = 0
         moe_layers = [layer for _, layer in iter_moe_layers(self.model)]
@@ -196,6 +208,11 @@ class ExpertTrainer:
 
             # Get the actual input the router received during this forward pass
             hs_flat = self._router_inputs[router_idx]
+            if token_mask is not None and token_mask.numel() == hs_flat.shape[0]:
+                hs_flat = hs_flat[token_mask]
+                if hs_flat.shape[0] == 0:
+                    router_idx += 1
+                    continue
 
             router = layer.router
 
@@ -242,7 +259,9 @@ class ExpertTrainer:
             **kwargs,
         )
         task_loss = outputs.loss
-        kl_loss = self._compute_kl_loss()
+        attention_mask = kwargs.get("attention_mask")
+        token_mask = attention_mask.bool() if attention_mask is not None else None
+        kl_loss = self._compute_kl_loss(token_mask)
 
         return task_loss, kl_loss
 
@@ -273,6 +292,19 @@ class ExpertTrainer:
 
         task_loss, kl_loss = self.compute_loss(input_ids, labels, **kwargs)
         total_loss = task_loss + self.kl_weight * kl_loss
+        if not torch.isfinite(total_loss):
+            self.nonfinite_steps += 1
+            self.optimizer.zero_grad(set_to_none=True)
+            self._micro_step = 0
+            msg = (f"non-finite loss (task={task_loss.item()}, kl={kl_loss.item()}) "
+                   f"at micro-step {self.optimizer_steps * self.grad_accum_steps}")
+            if self.abort_on_nonfinite:
+                raise FloatingPointError(msg)
+            import warnings
+            warnings.warn(msg + "; skipping step", stacklevel=2)
+            return {"task_loss": task_loss.item(), "kl_loss": kl_loss.item(),
+                    "total_loss": total_loss.item(), "lr": self.current_lr,
+                    "grad_norm": None, "stepped": False, "skipped": True}
         self.backend.backward(total_loss / self.grad_accum_steps)
         self._micro_step += 1
 
@@ -295,4 +327,5 @@ class ExpertTrainer:
             "lr": self.current_lr,
             "grad_norm": grad_norm,
             "stepped": stepped,
+            "skipped": False,
         }

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -50,3 +50,51 @@ class TestPaddingInvariance:
             )
             naive, _ = trainer.compute_loss(input_ids=input_ids, labels=input_ids.clone())
         assert abs(masked.item() - naive.item()) > 1e-4
+
+
+class TestKLMaskAndNaNGuard:
+    def test_kl_ignores_pad_positions(self, tiny_gemma4_moe):
+        """KL over a padded batch with the token mask == KL over the unpadded sequences."""
+        model = tiny_gemma4_moe.eval()
+        trainer = ExpertTrainer(model, [1], train_full_router=True)
+        # perturb the router so KL is non-zero
+        with torch.no_grad():
+            for layer in model.model.layers:
+                layer.router.proj.weight.add_(0.05 * torch.randn_like(layer.router.proj.weight))
+        a = torch.randint(1, 256, (20,)).tolist()
+        b = torch.randint(1, 256, (7,)).tolist()
+        input_ids, attention_mask, labels = _masked_batch(a, b)
+        with torch.no_grad():
+            _, kl_masked = trainer.compute_loss(input_ids=input_ids, labels=labels,
+                                                attention_mask=attention_mask)
+            # reference: token-weighted mean over the two unpadded sequences
+            tot, n = 0.0, 0
+            for ids in (a, b):
+                t = torch.tensor([ids])
+                _, kl = trainer.compute_loss(input_ids=t, labels=t)
+                tot += kl.item() * len(ids)
+                n += len(ids)
+        assert kl_masked.item() > 0
+        assert abs(kl_masked.item() - tot / n) < 5e-3
+
+    def test_nonfinite_loss_aborts_by_default(self, tiny_gemma4_moe, sample_batch):
+        import pytest
+        model = tiny_gemma4_moe
+        trainer = ExpertTrainer(model, [1])
+        with torch.no_grad():
+            model.lm_head.weight.fill_(float("nan"))
+        with pytest.raises(FloatingPointError):
+            trainer.train_step(**sample_batch)
+        assert trainer.nonfinite_steps == 1
+
+    def test_nonfinite_loss_can_be_skipped(self, tiny_gemma4_moe, sample_batch):
+        model = tiny_gemma4_moe
+        trainer = ExpertTrainer(model, [1], abort_on_nonfinite=False)
+        with torch.no_grad():
+            model.lm_head.weight.fill_(float("nan"))
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            m = trainer.train_step(**sample_batch)
+        assert m["skipped"] and not m["stepped"]
+        assert all(p.grad is None for p in trainer.trainable_parameters)


### PR DESCRIPTION
Regression fix for the NaN runs (jobs 2176232/2176248/2176249). Three tests: masked KL equals the unpadded token-weighted KL; non-finite loss aborts by default and increments a counter; skip mode leaves no grads. run.json records nonfinite_steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)