### PR TITLE
feat: --top_k for training (train experts at a different active-expert count)

### DIFF
--- a/src/exex/cli/train.py
+++ b/src/exex/cli/train.py
@@ -37,6 +37,9 @@ def build_parser():
     p.add_argument("--clone_router_noise", type=float, default=0.0,
                    help="With --clone_from: relative Gaussian noise on the new slot's "
                         "router row so it does not tie with its source (0 = verbatim copy)")
+    p.add_argument("--top_k", type=int, default=None,
+                   help="Train (and periodically eval) with this many active experts per "
+                        "token instead of the checkpoint default; recorded in run.json")
     p.add_argument("--label", default=None,
                    help="Label recorded in the cartridge manifest / config")
     # optimisation
@@ -107,6 +110,10 @@ def main(argv=None):
     tokenizer = AutoTokenizer.from_pretrained(args.model_path)
 
     manager = ExpertManager.from_model(model)
+    if args.top_k is not None:
+        from exex.loading import set_top_k
+        prev = set_top_k(model, args.top_k)
+        print(f"Router top-k for training: {prev} -> {args.top_k}", flush=True)
     if args.clone_from is not None:
         new_idx = manager.clone_expert(source_idx=args.clone_from, label=args.label,
                                        router_noise=args.clone_router_noise, seed=args.seed)
@@ -226,7 +233,8 @@ def main(argv=None):
         model.config.save_pretrained(args.output_dir)
 
     run = {"args": vars(args), "expert_indices": expert_indices,
-           "num_experts": manager.arch.num_experts, "trainable_params": n_trainable,
+           "num_experts": manager.arch.num_experts, "top_k": args.top_k,
+           "trainable_params": n_trainable,
            "optimizer_steps": step, "tokens_seen": tokens_seen,
            "nonfinite_steps": trainer.nonfinite_steps,
            "elapsed_s": round(time.time() - t0, 1), "eval_ppl_history": eval_history,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -377,3 +377,16 @@ def test_script_shims_import_cli_main(shim, module):
     import importlib
 
     assert mod.main is importlib.import_module(f"exex.cli.{module}").main
+
+
+
+def test_train_with_top_k_override(ws, tiny_model_dir, jsonl_path):
+    out = ws / "run_topk"
+    train.main([
+        "--model_path", tiny_model_dir, "--dataset", jsonl_path,
+        "--expert_indices", "1", "--top_k", "3", "--output_dir", str(out), *TRAIN_ARGS,
+    ])
+    run = _read_json(os.path.join(out, "run.json"))
+    assert run["top_k"] == 3
+    assert _read_json(os.path.join(out, "config.json"))["top_k_experts"] == 3
+    _rm(out)


### PR DESCRIPTION
Needed for the pre-approved k=12 training arm: set the router top-k before training so the expert is optimised for the active-expert count it will be evaluated at. Recorded in run.json and the saved config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)