### PR TITLE
fix: force right padding in the training CLI (Gemma 4 tokenizers pad left)

### DIFF
--- a/src/exex/cli/train.py
+++ b/src/exex/cli/train.py
@@ -108,6 +108,13 @@ def main(argv=None):
     print(f"Loading model from {args.model_path}...", flush=True)
     model = AutoModelForCausalLM.from_pretrained(args.model_path, **load_kwargs)
     tokenizer = AutoTokenizer.from_pretrained(args.model_path)
+    # Right-pad for training: with a causal mask, real tokens then never see a
+    # pad token even when no attention mask is passed. Gemma 4 tokenizers
+    # default to LEFT padding (generation-friendly), which silently let real
+    # tokens attend to pads in every batch>1 run before 2026-09-07.
+    if tokenizer.padding_side != "right":
+        print(f"tokenizer.padding_side {tokenizer.padding_side!r} -> 'right' for training", flush=True)
+        tokenizer.padding_side = "right"
 
     manager = ExpertManager.from_model(model)
     if args.top_k is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -390,3 +390,24 @@ def test_train_with_top_k_override(ws, tiny_model_dir, jsonl_path):
     assert run["top_k"] == 3
     assert _read_json(os.path.join(out, "config.json"))["top_k_experts"] == 3
     _rm(out)
+
+
+def test_train_forces_right_padding(ws, tiny_model_dir, jsonl_path, monkeypatch, capsys):
+    """A left-padding tokenizer must be flipped to right padding for training."""
+    from transformers import AutoTokenizer
+
+    orig = AutoTokenizer.from_pretrained
+
+    def left_padding(*a, **k):
+        tok = orig(*a, **k)
+        tok.padding_side = "left"
+        return tok
+
+    monkeypatch.setattr(AutoTokenizer, "from_pretrained", staticmethod(left_padding))
+    out = ws / "run_rightpad"
+    train.main([
+        "--model_path", tiny_model_dir, "--dataset", jsonl_path,
+        "--expert_indices", "1", "--output_dir", str(out), *TRAIN_ARGS,
+    ])
+    assert "-> 'right'" in capsys.readouterr().out
+    _rm(out)


### PR DESCRIPTION
Found while diagnosing the NaN runs: `padding_side` is left for the Gemma 4 tokenizer. Test monkeypatches a left-padding tokenizer and asserts the flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)